### PR TITLE
Fix Invalid cross-device link

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -3,6 +3,12 @@
 Changelog
 ---------
 
+.. _release-0.5.3:
+
+0.5.3 - TBD
+    * Resolve Invalid cross-device link error when default temporary folder
+      is on a different device to the scratch path.
+
 .. _release-0.5.2:
 
 0.5.2 - 22 May 2024


### PR DESCRIPTION
Prior to this when the reports are being created we protect against partial writes by creating the files in a temporary location and then renaming those files.

It turns out that it's very possible the default temporary location and the scratch path are on different devices and the pathlib rename functionality doesn't know how to deal with that.

This change fixes that by making sure the temporary location is added to the scratch path so that it's on the same device