### PR TITLE
Improve narrowing return types

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -3,6 +3,13 @@
 Changelog
 ---------
 
+.. _release-0.5.4:
+
+0.5.4 - TBD
+    * Will now check return types for methods and functions more thorouhgly
+    * Will throw errors if a type guard is used with a concrete annotation that uses
+      a type var (mypy plugin system is limited in a way that makes this impossible to implement)
+
 .. _release-0.5.3:
 
 0.5.3 - 25 May 2024

--- a/extended_mypy_django_plugin/plugin/_known_annotations.py
+++ b/extended_mypy_django_plugin/plugin/_known_annotations.py
@@ -1,0 +1,7 @@
+import enum
+
+
+class KnownAnnotations(enum.Enum):
+    CONCRETE = "extended_mypy_django_plugin.annotations.Concrete"
+    CONCRETE_QUERYSET = "extended_mypy_django_plugin.annotations.ConcreteQuerySet"
+    DEFAULT_QUERYSET = "extended_mypy_django_plugin.annotations.DefaultQuerySet"

--- a/extended_mypy_django_plugin/plugin/_plugin.py
+++ b/extended_mypy_django_plugin/plugin/_plugin.py
@@ -1,5 +1,4 @@
 import collections
-import enum
 import sys
 from typing import Generic
 
@@ -26,7 +25,16 @@ from mypy_django_plugin.transformers.managers import (
 )
 from typing_extensions import assert_never
 
-from . import _config, _dependencies, _helpers, _hook, _reports, _store, actions
+from . import (
+    _config,
+    _dependencies,
+    _helpers,
+    _hook,
+    _known_annotations,
+    _reports,
+    _store,
+    actions,
+)
 
 
 class Hook(
@@ -62,10 +70,7 @@ class ExtendedMypyStubs(main.NewSemanalDjangoPlugin):
 
     plugin_config: _config.Config
 
-    class Annotations(enum.Enum):
-        CONCRETE = "extended_mypy_django_plugin.annotations.Concrete"
-        CONCRETE_QUERYSET = "extended_mypy_django_plugin.annotations.ConcreteQuerySet"
-        DEFAULT_QUERYSET = "extended_mypy_django_plugin.annotations.DefaultQuerySet"
+    Annotations = _known_annotations.KnownAnnotations
 
     def __init__(self, options: Options, mypy_version_tuple: tuple[int, int]) -> None:
         super(main.NewSemanalDjangoPlugin, self).__init__(options)

--- a/extended_mypy_django_plugin/plugin/actions/_type_analyze.py
+++ b/extended_mypy_django_plugin/plugin/actions/_type_analyze.py
@@ -30,7 +30,7 @@ class TypeAnalyzing:
         type_arg = get_proper_type(self.api.analyze_type(args[0]))
 
         if not isinstance(type_arg, Instance):
-            return UnionType(())
+            return unbound_type
 
         concrete = tuple(
             self.store.retrieve_concrete_children_types(

--- a/extended_mypy_django_plugin/plugin/actions/_type_checker.py
+++ b/extended_mypy_django_plugin/plugin/actions/_type_checker.py
@@ -1,16 +1,15 @@
+import dataclasses
+from collections.abc import Iterator, Mapping
 from typing import Protocol
 
 from mypy.checker import TypeChecker
-from mypy.nodes import CallExpr, MemberExpr, TypeInfo
-from mypy.plugin import (
-    AttributeContext,
-    FunctionContext,
-)
+from mypy.nodes import CallExpr, Context, MemberExpr, TypeInfo
+from mypy.plugin import AttributeContext, FunctionContext, MethodContext
 from mypy.types import (
     AnyType,
     CallableType,
-    FormalArgument,
     Instance,
+    ProperType,
     TypeOfAny,
     TypeType,
     TypeVarType,
@@ -19,8 +18,13 @@ from mypy.types import (
     get_proper_type,
 )
 from mypy.types import Type as MypyType
+from typing_extensions import Self
 
-from .. import _store
+from .. import _known_annotations, _store
+
+
+class LookupFunction(Protocol):
+    def __call__(self, fullname: str) -> TypeInfo | None: ...
 
 
 class ResolveManagerMethodFromInstance(Protocol):
@@ -29,21 +33,146 @@ class ResolveManagerMethodFromInstance(Protocol):
     ) -> MypyType: ...
 
 
+def _find_type_vars(
+    item: MypyType, _chain: list[ProperType] | None = None
+) -> list[TypeVarType | str]:
+    if _chain is None:
+        _chain = []
+
+    result: list[TypeVarType | str] = []
+
+    item = get_proper_type(item)
+
+    if isinstance(item, TypeVarType):
+        result.append(item)
+
+    elif isinstance(item, UnboundType):
+        if item.args:
+            for arg in item.args:
+                if arg not in _chain:
+                    _chain.append(get_proper_type(arg))
+                    result.extend(_find_type_vars(arg, _chain=_chain))
+        else:
+            _chain.append(item)
+            result.append(item.name)
+
+    return result
+
+
+@dataclasses.dataclass
+class BasicTypeInfo:
+    is_type: bool
+    api: TypeChecker
+    func: CallableType
+
+    item: ProperType
+    type_vars: list[TypeVarType | str]
+    concrete_annotation: _known_annotations.KnownAnnotations | None
+
+    @classmethod
+    def create(cls, api: TypeChecker, func: CallableType, item: MypyType | None = None) -> Self:
+        is_type: bool = False
+
+        if item is None:
+            item = func.ret_type
+
+        item = get_proper_type(item)
+        if isinstance(item, TypeType):
+            is_type = True
+            item = item.item
+
+        type_vars = _find_type_vars(item)
+
+        concrete_annotation: _known_annotations.KnownAnnotations | None = None
+        if isinstance(item, UnboundType):
+            try:
+                named_generic_type_name = api.named_generic_type(
+                    item.name, list(item.args)
+                ).type.fullname
+            except AssertionError:
+                named_generic_type_name = ""
+
+            try:
+                concrete_annotation = _known_annotations.KnownAnnotations(named_generic_type_name)
+            except ValueError:
+                pass
+
+        return cls(
+            api=api,
+            func=func,
+            item=item,
+            is_type=is_type,
+            type_vars=type_vars,
+            concrete_annotation=concrete_annotation,
+        )
+
+    @property
+    def contains_concrete_annotation(self) -> bool:
+        if self.concrete_annotation is not None:
+            return True
+
+        for item in self.items():
+            if item is not self and item.contains_concrete_annotation:
+                return True
+
+        return False
+
+    def items(self) -> Iterator[Self]:
+        if isinstance(self.item, UnionType):
+            for item in self.item.items:
+                yield self.__class__.create(self.api, self.func, item)
+        else:
+            yield self
+
+    def map_type_vars(
+        self, context: Context, callee_arg_names: list[str | None], arg_types: list[list[MypyType]]
+    ) -> Mapping[TypeVarType | str, ProperType]:
+        result: dict[TypeVarType | str, ProperType] = {}
+
+        formal_by_name = {arg.name: arg.typ for arg in self.func.formal_arguments()}
+
+        for arg_name, arg_type in zip(callee_arg_names, arg_types):
+            underlying = get_proper_type(formal_by_name[arg_name])
+            if isinstance(underlying, TypeType):
+                underlying = underlying.item
+
+            if isinstance(underlying, TypeVarType):
+                found_type = get_proper_type(arg_type[0])
+                if isinstance(found_type, CallableType):
+                    found_type = get_proper_type(found_type.ret_type)
+
+                result[underlying] = found_type
+                result[underlying.name] = found_type
+
+        for type_var in self.type_vars:
+            if type_var not in result:
+                self.api.fail(
+                    f"Failed to find an argument that matched the type var {type_var}", context
+                )
+                result[type_var] = AnyType(TypeOfAny.from_error)
+
+        return result
+
+
 class TypeChecking:
-    def __init__(self, store: _store.Store, *, api: TypeChecker) -> None:
+    def __init__(
+        self, store: _store.Store, *, api: TypeChecker, lookup_info: LookupFunction
+    ) -> None:
         self.api = api
         self.store = store
+        self._lookup_info = lookup_info
 
-    def modify_default_queryset_return_type(
-        self,
-        ctx: FunctionContext,
-        *,
-        desired_annotation_fullname: str,
-    ) -> MypyType | None:
-        if not isinstance(ctx.default_return_type, UnboundType):
-            return None
+    def _named_type(self, fullname: str, args: list[MypyType] | None = None) -> Instance:
+        """
+        Copied from what semantic analyzer does
+        """
+        node = self._lookup_info(fullname)
+        assert isinstance(node, TypeInfo)
+        if args:
+            return Instance(node, args)
+        return Instance(node, [AnyType(TypeOfAny.special_form)] * len(node.defn.type_vars))
 
-        context = ctx.context
+    def _get_info(self, context: Context) -> BasicTypeInfo | None:
         if not isinstance(context, CallExpr):
             return None
 
@@ -58,59 +187,119 @@ class TypeChecking:
         if not isinstance(func, CallableType):
             return None
 
-        if not isinstance(func.ret_type, UnboundType):
+        return BasicTypeInfo.create(api=self.api, func=func)
+
+    def modify_return_type(self, ctx: MethodContext | FunctionContext) -> MypyType | None:
+        info = self._get_info(ctx.context)
+        if info is None:
             return None
 
-        as_generic_type = self.api.named_generic_type(func.ret_type.name, [func.ret_type.args[0]])
-        if as_generic_type.type.fullname != desired_annotation_fullname:
+        if not info.contains_concrete_annotation:
             return None
 
-        if len(func.ret_type.args) != 1:
-            self.api.fail("DefaultQuerySet takes only one argument", context)
-            return AnyType(TypeOfAny.from_error)
+        result: list[MypyType] = []
 
-        found_type: MypyType | None = None
+        type_vars_map = info.map_type_vars(ctx.context, ctx.callee_arg_names, ctx.arg_types)
 
-        type_var = func.ret_type.args[0]
+        for item in info.items():
+            Known = _known_annotations.KnownAnnotations
+            if item.concrete_annotation is None:
+                if isinstance(item.item, TypeVarType):
+                    result.append(type_vars_map.get(item.item, item.item))
+                elif isinstance(item.item, UnboundType) and len(item.item.args) == 0:
+                    result.append(type_vars_map.get(item.item.name, item.item))
+                else:
+                    result.append(item.item)
+                continue
 
-        if isinstance(type_var, UnboundType):
-            match: FormalArgument | None = None
-            for arg in func.formal_arguments():
-                arg_name: str | None = None
-                formal_arg_type = get_proper_type(arg.typ)
-                if isinstance(formal_arg_type, TypeType) and isinstance(
-                    formal_arg_type.item, TypeVarType
-                ):
-                    arg_name = formal_arg_type.item.name
+            is_type = item.is_type and not info.is_type
 
-                elif isinstance(arg, TypeVarType):
-                    arg_name = formal_arg_type.name
+            # It has to be an instance or unbound type if it has a concrete annotation
+            assert isinstance(item.item, Instance | UnboundType)
 
-                if arg_name and arg_name == type_var.name:
-                    match = arg
-                    break
-
-            if match is not None:
-                for arg_name, arg_type in zip(ctx.callee_arg_names, ctx.arg_types):
-                    if arg_name == match.name:
-                        found_type = arg_type[0]
-
-            if found_type is None:
-                self.api.fail("Failed to find an argument that matched the type var", context)
+            if len(item.item.args) != 1:
+                self.api.fail("Concrete Annotations must take exactly one argument", ctx.context)
                 return AnyType(TypeOfAny.from_error)
 
-            found_type = get_proper_type(found_type)
-            if isinstance(found_type, CallableType):
-                type_var = found_type.ret_type
-            else:
-                type_var = found_type
+            model = item.item.args[0]
+            if isinstance(model, TypeVarType | UnboundType):
+                found: ProperType | None = None
+                if isinstance(model, TypeVarType):
+                    found = type_vars_map.get(model)
+                elif isinstance(model, UnboundType):
+                    found = type_vars_map.get(model.name)
 
-        if not isinstance(type_var, Instance | UnionType):
-            self.api.fail("Don't know what to do with what DefaultQuerySet was given", context)
-            return AnyType(TypeOfAny.from_error)
+                if found is None:
+                    self.api.fail(
+                        f"Can't determine what model the type var {model} represents", ctx.context
+                    )
+                    return AnyType(TypeOfAny.from_error)
+                else:
+                    if isinstance(found, AnyType):
+                        return found
 
+                    model = found
+
+            model = get_proper_type(model)
+            instances: list[Instance] = []
+            if isinstance(model, Instance):
+                instances.append(model)
+            elif isinstance(model, UnionType):
+                for member in model.items:
+                    member = get_proper_type(member)
+                    if isinstance(member, Instance):
+                        instances.append(member)
+                    else:
+                        self.api.fail(
+                            f"Failed to have a list of instances to find for a concrete annotation, {member}",
+                            ctx.context,
+                        )
+                        return AnyType(TypeOfAny.from_error)
+
+            made: MypyType
+            if item.concrete_annotation is Known.CONCRETE:
+                made = self.get_concrete_types(ctx.context, instances=instances)
+            elif item.concrete_annotation is Known.DEFAULT_QUERYSET:
+                made = self.get_default_queryset_return_type(
+                    ctx.context, instances=UnionType(tuple(instances))
+                )
+            elif item.concrete_annotation is Known.CONCRETE_QUERYSET:
+                made = self.get_concrete_queryset_return_type(ctx.context, instances=instances)
+
+            if is_type:
+                made = TypeType(made)
+
+            result.append(made)
+
+        final: MypyType = UnionType(tuple(result))
+        if info.is_type:
+            final = TypeType(final)
+
+        return final
+
+    def get_concrete_queryset_return_type(
+        self, context: Context, *, instances: list[Instance]
+    ) -> MypyType:
+        result: list[MypyType] = []
+        for concrete in self.get_concrete_types(context, instances=instances).items:
+            concrete = get_proper_type(concrete)
+            assert isinstance(concrete, Instance)
+            try:
+                result.extend(self.store.realise_querysets(concrete, self.lookup_info))
+            except _store.RestartDmypy:
+                self.api.fail("You probably need to restart dmypy", context)
+                return AnyType(TypeOfAny.from_error)
+            except _store.UnionMustBeOfTypes:
+                self.api.fail("Union must be of instances of models", context)
+                return AnyType(TypeOfAny.from_error)
+
+        return UnionType(tuple(result))
+
+    def get_default_queryset_return_type(
+        self, context: Context, *, instances: Instance | UnionType
+    ) -> MypyType:
         try:
-            querysets = tuple(self.store.realise_querysets(type_var, self.lookup_info))
+            querysets = tuple(self.store.realise_querysets(instances, self.lookup_info))
         except _store.RestartDmypy:
             self.api.fail("You probably need to restart dmypy", context)
             return AnyType(TypeOfAny.from_error)
@@ -119,6 +308,16 @@ class TypeChecking:
             return AnyType(TypeOfAny.from_error)
         else:
             return UnionType(querysets)
+
+    def get_concrete_types(self, context: Context, *, instances: list[Instance]) -> UnionType:
+        result: list[MypyType] = []
+        for item in instances:
+            result.extend(
+                self.store.retrieve_concrete_children_types(
+                    item.type, self.lookup_info, self._named_type
+                )
+            )
+        return UnionType(tuple(result))
 
     def extended_get_attribute_resolve_manager_method(
         self,

--- a/tests/test_concrete_annotations.py
+++ b/tests/test_concrete_annotations.py
@@ -9,26 +9,49 @@ class TestConcreteAnnotations:
                 "main.py",
                 """
                 from extended_mypy_django_plugin import Concrete, ConcreteQuerySet, DefaultQuerySet
+                from typing import cast, TypeGuard
 
-                from myapp.models import Parent
+                from myapp.models import Parent, Child1
 
                 models: Concrete[Parent]
                 reveal_type(models)
 
                 qs: ConcreteQuerySet[Parent]
                 reveal_type(qs)
+
+                def check_cls_with_type_guard(cls: type[Parent]) -> TypeGuard[type[Concrete[Parent]]]:
+                    return True
+
+                def check_instance_with_type_guard(cls: Parent) -> TypeGuard[Concrete[Parent]]:
+                    return True
+
+                cls: type[Parent] = Child1
+                assert check_cls_with_type_guard(cls)
+                reveal_type(cls)
+
+                instance: Parent = cast(Child1, None)
+                assert check_instance_with_type_guard(instance)
+                reveal_type(instance)
                 """,
             )
 
             (
                 expected.on("main.py")
                 .add_revealed_type(
-                    6,
+                    7,
                     "Union[myapp.models.Child1, myapp.models.Child2, myapp.models.Child3, myapp2.models.ChildOther]",
                 )
                 .add_revealed_type(
-                    9,
+                    10,
                     "Union[django.db.models.query._QuerySet[myapp.models.Child1, myapp.models.Child1], myapp.models.Child2QuerySet, django.db.models.query._QuerySet[myapp.models.Child3, myapp.models.Child3], django.db.models.query._QuerySet[myapp2.models.ChildOther, myapp2.models.ChildOther]]",
+                )
+                .add_revealed_type(
+                    20,
+                    "Union[type[myapp.models.Child1], type[myapp.models.Child2], type[myapp.models.Child3], type[myapp2.models.ChildOther]]",
+                )
+                .add_revealed_type(
+                    24,
+                    "Union[myapp.models.Child1, myapp.models.Child2, myapp.models.Child3, myapp2.models.ChildOther]",
                 )
             )
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,89 @@
+import importlib.metadata
+
+from extended_mypy_django_plugin_test_driver import OutputBuilder, Scenario
+
+
+class TestErrors:
+    def test_cant_use_typevar_concrete_annotation_in_function_or_method_typeguard(
+        self, scenario: Scenario
+    ) -> None:
+        @scenario.run_and_check_mypy_after
+        def _(expected: OutputBuilder) -> None:
+            scenario.make_file(
+                "main.py",
+                """
+                from typing import TypeGuard, TypeVar, cast
+
+                from myapp.models import Child1, Parent
+
+                from extended_mypy_django_plugin import Concrete, ConcreteQuerySet, DefaultQuerySet
+
+                T_Parent = Concrete.type_var("T_Parent", Parent)
+
+                def function_with_type_typeguard(
+                    cls: type[Parent], expect: type[T_Parent]
+                ) -> TypeGuard[type[Concrete[T_Parent]]]:
+                    return hasattr(cls, "objects")
+
+                cls1: type[Parent] = Child1
+                assert function_with_type_typeguard(cls1, Parent)
+                reveal_type(cls1)
+
+                def function_with_instance_typeguard(
+                    instance: Parent, expect: type[T_Parent]
+                ) -> TypeGuard[Concrete[T_Parent]]:
+                    return True
+
+                instance1: Parent = cast(Child1, None)
+                assert function_with_instance_typeguard(instance1, Parent)
+                reveal_type(instance1)
+
+                class Logic:
+                    def method_with_type_typeguard(
+                        self, cls: type[Parent], expect: type[T_Parent]
+                    ) -> TypeGuard[type[Concrete[T_Parent]]]:
+                        return hasattr(cls, "objects")
+
+                    def method_with_instance_typeguard(
+                        self, instance: T_Parent, expect: type[T_Parent]
+                    ) -> TypeGuard[Concrete[T_Parent]]:
+                        return True
+
+                logic = Logic()
+                cls2: type[Parent] = Child1
+                assert logic.method_with_type_typeguard(cls2, Parent)
+                reveal_type(cls2)
+
+                instance2: Parent = cast(Child1, None)
+                assert logic.method_with_instance_typeguard(instance2, Parent)
+                reveal_type(instance2)
+                """,
+            )
+
+            out = """
+            main:15: error: Can't use a TypeGuard that uses a Concrete Annotation that uses type variables  [misc]
+            main:15: error: Value of type variable "T_Parent" of "function_with_type_typeguard" cannot be "Parent"  [type-var]
+            main:15: error: Only concrete class can be given where "type[Parent]" is expected  [type-abstract]
+            main:16: note: Revealed type is "type[Concrete?[T_Parent?]]"
+            main:24: error: Can't use a TypeGuard that uses a Concrete Annotation that uses type variables  [misc]
+            main:24: error: Value of type variable "T_Parent" of "function_with_instance_typeguard" cannot be "Parent"  [type-var]
+            main:24: error: Only concrete class can be given where "type[Parent]" is expected  [type-abstract]
+            main:25: note: Revealed type is "Concrete?[T_Parent?]"
+            main:40: error: Can't use a TypeGuard that uses a Concrete Annotation that uses type variables  [misc]
+            main:40: error: Value of type variable "T_Parent" of "method_with_type_typeguard" of "Logic" cannot be "Parent"  [type-var]
+            main:40: error: Only concrete class can be given where "type[Parent]" is expected  [type-abstract]
+            main:41: note: Revealed type is "type[Concrete?[T_Parent?]]"
+            main:44: error: Can't use a TypeGuard that uses a Concrete Annotation that uses type variables  [misc]
+            main:44: error: Value of type variable "T_Parent" of "method_with_instance_typeguard" of "Logic" cannot be "Parent"  [type-var]
+            main:44: error: Only concrete class can be given where "type[Parent]" is expected  [type-abstract]
+            main:45: note: Revealed type is "Concrete?[T_Parent?]"
+            """
+
+            if importlib.metadata.version("mypy") == "1.4.0":
+                out = "\n".join(
+                    line
+                    for line in out.split("\n")
+                    if "Only concrete class can be given" not in line
+                ).replace('Revealed type is "type', 'Revealed type is "Type')
+
+            expected.from_out(out)


### PR DESCRIPTION
Prior to this we would only resolve concrete annotations that used type variables on functions. This change makes it so that logic works for all annotations rather than only DefaultQuerySet, and also on methods.

It also adds logic to give a useful warning when a type guard is used with a concrete annotation that depends on a typevar. In that situation the mypy plugin system doesn't not provide an opportunity to resolve such an annotation where it can also modify the type guard.