### PR TITLE
Understand type on annotations better

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -12,6 +12,7 @@ Changelog
     * The concrete annotations understand ``type[Annotation[inner]]`` and ``Annotation[type[inner]]``
       better now and will do the right thing
     * When an annotation would transform into a Union of one item, now it becomes that one item
+    * Removed ``ConcreteQuerySet`` and made ``DefaultQuerySet`` take on that functionality
 
 .. _release-0.5.3:
 

--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -9,6 +9,9 @@ Changelog
     * Will now check return types for methods and functions more thorouhgly
     * Will throw errors if a type guard is used with a concrete annotation that uses
       a type var (mypy plugin system is limited in a way that makes this impossible to implement)
+    * The concrete annotations understand ``type[Annotation[inner]]`` and ``Annotation[type[inner]]``
+      better now and will do the right thing
+    * When an annotation would transform into a Union of one item, now it becomes that one item
 
 .. _release-0.5.3:
 

--- a/docs/api/primer.rst
+++ b/docs/api/primer.rst
@@ -196,6 +196,4 @@ Annotations
 
 .. autoclass:: extended_mypy_django_plugin.Concrete
 
-.. autoclass:: extended_mypy_django_plugin.ConcreteQuerySet
-
 .. autoclass:: extended_mypy_django_plugin.DefaultQuerySet

--- a/docs/api/usage.rst
+++ b/docs/api/usage.rst
@@ -72,19 +72,19 @@ model, create a ``TypeVar`` object using ``Concrete.type_var``:
         return cls.objects.create()
 
 
-ConcreteQuerySet
-----------------
+DefaultQuerySet
+---------------
 
 To create a union of the default querysets for the concrete models of an
-abstract class, use the ``ConcreteQuerySet`` annotation:
+abstract class, use the ``DefaultQuerySet`` annotation:
 
 .. code-block:: python
 
-    from extended_mypy_django_plugin import ConcreteQuerySet
+    from extended_mypy_django_plugin import DefaultQuerySet
     from django.db import models
 
 
-    qs: ConcreteQuerySet[AbstractModel]
+    qs: DefaultQuerySet[AbstractModel]
 
     # --------------
     # Equivalent to
@@ -92,10 +92,7 @@ abstract class, use the ``ConcreteQuerySet`` annotation:
 
     qs: models.QuerySet[Concrete1] | Concrete2QuerySet | models.QuerySet[Concrete3]
 
-DefaultQuerySet
----------------
-
-This is similar to ``ConcreteQuerySet`` but works on the concrete models themselves:
+This also works on the concrete models themselves:
 
 .. code-block:: python
 

--- a/example/djangoexample/views.py
+++ b/example/djangoexample/views.py
@@ -1,6 +1,6 @@
 from django.http import HttpRequest, HttpResponse, HttpResponseBase
 
-from extended_mypy_django_plugin import Concrete, ConcreteQuerySet, DefaultQuerySet
+from extended_mypy_django_plugin import Concrete, DefaultQuerySet
 
 from .exampleapp.models import Child1, Child2, Parent
 
@@ -11,7 +11,7 @@ def make_child(child: type[T_Child]) -> T_Child:
     return child.objects.create()
 
 
-def make_any_queryset(child: type[Concrete[Parent]]) -> ConcreteQuerySet[Parent]:
+def make_any_queryset(child: type[Concrete[Parent]]) -> DefaultQuerySet[Parent]:
     return child.objects.all()
 
 

--- a/extended_mypy_django_plugin/__init__.py
+++ b/extended_mypy_django_plugin/__init__.py
@@ -1,3 +1,3 @@
-from .annotations import Concrete, ConcreteQuerySet, DefaultQuerySet
+from .annotations import Concrete, DefaultQuerySet
 
-__all__ = ["Concrete", "ConcreteQuerySet", "DefaultQuerySet"]
+__all__ = ["Concrete", "DefaultQuerySet"]

--- a/extended_mypy_django_plugin/annotations.py
+++ b/extended_mypy_django_plugin/annotations.py
@@ -5,7 +5,7 @@ from typing import Generic, TypeVar
 
 from django.db import models
 
-T_Parent = TypeVar("T_Parent", bound=models.Model)
+T_Parent = TypeVar("T_Parent")
 
 
 class Concrete(Generic[T_Parent]):

--- a/extended_mypy_django_plugin/annotations.py
+++ b/extended_mypy_django_plugin/annotations.py
@@ -60,16 +60,9 @@ class Concrete(Generic[T_Parent]):
         return TypeVar(name)
 
 
-class ConcreteQuerySet(Generic[T_Parent]):
-    """
-    This is used to annotate a model such that the mypy plugin may turn this into
-    a union of all the default querysets for all the concrete children of the
-    specified abstract model class.
-    """
-
-
 class DefaultQuerySet(Generic[T_Parent]):
     """
     This is used to annotate a model such that the mypy plugin may turn this into
-    the queryset type used by the default manager on the model.
+    a union of all the default querysets for all the concrete children of the
+    specified abstract model class, or of that model when it is a concrete model
     """

--- a/extended_mypy_django_plugin/plugin/_known_annotations.py
+++ b/extended_mypy_django_plugin/plugin/_known_annotations.py
@@ -7,5 +7,4 @@ class KnownClasses(enum.Enum):
 
 class KnownAnnotations(enum.Enum):
     CONCRETE = "extended_mypy_django_plugin.annotations.Concrete"
-    CONCRETE_QUERYSET = "extended_mypy_django_plugin.annotations.ConcreteQuerySet"
     DEFAULT_QUERYSET = "extended_mypy_django_plugin.annotations.DefaultQuerySet"

--- a/extended_mypy_django_plugin/plugin/_known_annotations.py
+++ b/extended_mypy_django_plugin/plugin/_known_annotations.py
@@ -1,6 +1,10 @@
 import enum
 
 
+class KnownClasses(enum.Enum):
+    CONCRETE = "extended_mypy_django_plugin.annotations.Concrete"
+
+
 class KnownAnnotations(enum.Enum):
     CONCRETE = "extended_mypy_django_plugin.annotations.Concrete"
     CONCRETE_QUERYSET = "extended_mypy_django_plugin.annotations.ConcreteQuerySet"

--- a/extended_mypy_django_plugin/plugin/_plugin.py
+++ b/extended_mypy_django_plugin/plugin/_plugin.py
@@ -185,8 +185,7 @@ class ExtendedMypyStubs(main.NewSemanalDjangoPlugin):
     @_hook.hook
     class get_type_analyze_hook(Hook[AnalyzeTypeContext, MypyType]):
         """
-        Resolve classes annotated with ``Concrete``, ``ConcreteQuerySet`` and
-        ``DefaultQuerySet``.
+        Resolve classes annotated with ``Concrete`` or ``DefaultQuerySet``.
         """
 
         def choose(self) -> bool:
@@ -206,9 +205,6 @@ class ExtendedMypyStubs(main.NewSemanalDjangoPlugin):
 
             if name is Known.CONCRETE:
                 method = type_analyzer.find_concrete_models
-
-            elif name is Known.CONCRETE_QUERYSET:
-                method = type_analyzer.find_concrete_querysets
 
             elif name is Known.DEFAULT_QUERYSET:
                 method = type_analyzer.find_default_queryset

--- a/extended_mypy_django_plugin/plugin/_plugin.py
+++ b/extended_mypy_django_plugin/plugin/_plugin.py
@@ -1,4 +1,6 @@
+import enum
 import sys
+from collections.abc import Callable
 from typing import Generic
 
 from mypy.checker import TypeChecker
@@ -141,8 +143,10 @@ class ExtendedMypyStubs(main.NewSemanalDjangoPlugin):
     @_hook.hook
     class get_dynamic_class_hook(Hook[DynamicClassDefContext, None]):
         """
-        This is used to find ``Concrete.type_var`` and turn that into a ``TypeVar``
-        representing each Concrete class of the abstract model provided.
+        This is used to find special methods on the ``Concrete`` class and do appropriate actions.
+
+        For ``Concrete.type_var`` we turn the result into a ``TypeVar`` that can only be one of
+        the concrete descendants of the specified class.
 
         So say we find::
 
@@ -153,21 +157,30 @@ class ExtendedMypyStubs(main.NewSemanalDjangoPlugin):
             T_Child = TypeVar("T_Child", Child1, Child2, Child3)
         """
 
+        class KnownConcreteMethods(enum.Enum):
+            type_var = "type_var"
+
+        method_name: KnownConcreteMethods
+
         def choose(self) -> bool:
             class_name, _, method_name = self.fullname.rpartition(".")
-            if method_name == "type_var":
+            try:
+                self.method_name = self.KnownConcreteMethods(method_name)
+            except ValueError:
+                return False
+            else:
                 info = self.plugin._get_typeinfo_or_none(class_name)
-                if info and info.has_base(ExtendedMypyStubs.Annotations.CONCRETE.value):
-                    return True
-
-            return False
+                return bool(info and info.has_base(_known_annotations.KnownClasses.CONCRETE.value))
 
         def run(self, ctx: DynamicClassDefContext) -> None:
             assert isinstance(ctx.api, SemanticAnalyzer)
 
             sem_analyzing = actions.SemAnalyzing(self.store, api=ctx.api)
 
-            return sem_analyzing.transform_type_var_classmethod(ctx)
+            if self.method_name is self.KnownConcreteMethods.type_var:
+                return sem_analyzing.transform_type_var_classmethod(ctx)
+            else:
+                assert_never(self.method_name)
 
     @_hook.hook
     class get_type_analyze_hook(Hook[AnalyzeTypeContext, MypyType]):
@@ -226,7 +239,7 @@ class ExtendedMypyStubs(main.NewSemanalDjangoPlugin):
                 ctx, resolve_manager_method_from_instance=resolve_manager_method_from_instance
             )
 
-    class SharedCallableHookLogic:
+    class SharedAnnotationHookLogic:
         """
         Shared logic for modifying the return type of methods and functions that use a concrete
         annotation with a type variable.
@@ -272,16 +285,22 @@ class ExtendedMypyStubs(main.NewSemanalDjangoPlugin):
             return type_checking.modify_return_type(ctx)
 
     class _get_method_or_function_hook(Hook[MethodContext | FunctionContext, MypyType]):
+        runner: Callable[[MethodContext | FunctionContext], MypyType | None]
+
         def extra_init(self) -> None:
-            self.shared_logic = self.plugin.SharedCallableHookLogic(
+            self.shared_logic = self.plugin.SharedAnnotationHookLogic(
                 fullname=self.fullname, plugin=self.plugin
             )
 
         def choose(self) -> bool:
-            return self.shared_logic.choose()
+            if self.shared_logic.choose():
+                self.runner = self.shared_logic.run
+                return True
+            else:
+                return False
 
         def run(self, ctx: FunctionContext | MethodContext) -> MypyType:
-            result = self.shared_logic.run(ctx)
+            result = self.runner(ctx)
             if result is not None:
                 return result
 

--- a/extended_mypy_django_plugin/plugin/_store.py
+++ b/extended_mypy_django_plugin/plugin/_store.py
@@ -5,7 +5,6 @@ from typing import Protocol
 from django.db import models
 from mypy.nodes import TypeInfo
 from mypy.types import Instance, UnionType, get_proper_type
-from mypy.types import Type as MypyType
 
 from ._reports import ModelModules
 
@@ -75,12 +74,12 @@ class Store:
         parent: TypeInfo,
         lookup_info: LookupFunction,
         lookup_instance: LookupInstanceFunction,
-    ) -> Sequence[MypyType]:
+    ) -> Sequence[Instance]:
         """
         Given a ``TypeInfo`` representing some model, return ``MypyType`` objects
         for all the concrete children related to the specified model.
         """
-        values: list[MypyType] = []
+        values: list[Instance] = []
 
         concrete_type_infos = self._retrieve_concrete_children_info_from_metadata(
             parent, lookup_info

--- a/extended_mypy_django_plugin/plugin/actions/_type_analyze.py
+++ b/extended_mypy_django_plugin/plugin/actions/_type_analyze.py
@@ -98,16 +98,17 @@ class TypeAnalyzing:
     def _make_union(
         self, is_type: bool, instances: Sequence[Instance]
     ) -> UnionType | Instance | TypeType:
-        made: UnionType | TypeType | Instance
-        if len(instances) == 1:
-            made = instances[0]
-        else:
-            made = UnionType(instances)
+        items: Sequence[UnionType | TypeType | Instance]
 
         if is_type:
-            return TypeType(made)
+            items = [item if isinstance(item, TypeType) else TypeType(item) for item in instances]
         else:
-            return made
+            items = instances
+
+        if len(items) == 1:
+            return items[0]
+        else:
+            return UnionType(tuple(items))
 
     def find_concrete_models(self, unbound_type: UnboundType) -> MypyType:
         is_type, concrete = self._analyze_first_type_arg(unbound_type)

--- a/extended_mypy_django_plugin/plugin/actions/_type_analyze.py
+++ b/extended_mypy_django_plugin/plugin/actions/_type_analyze.py
@@ -1,11 +1,14 @@
+from collections.abc import Iterator, Sequence
+
 from mypy.nodes import TypeInfo
 from mypy.semanal import SemanticAnalyzer
 from mypy.typeanal import TypeAnalyser
 from mypy.types import (
     AnyType,
     Instance,
+    ProperType,
     TypeOfAny,
-    TypeVarType,
+    TypeType,
     UnboundType,
     UnionType,
     get_proper_type,
@@ -25,45 +28,91 @@ class TypeAnalyzing:
         self.sem_api = sem_api
         self.store = store
 
-    def find_concrete_models(self, unbound_type: UnboundType) -> MypyType:
+    def _flatten_union(self, typ: ProperType) -> Iterator[ProperType]:
+        if isinstance(typ, UnionType):
+            for item in typ.items:
+                yield from self._flatten_union(get_proper_type(item))
+        else:
+            yield typ
+
+    def _analyze_first_type_arg(
+        self, unbound_type: UnboundType, expand: bool = True
+    ) -> tuple[bool, Sequence[Instance] | None]:
         args = unbound_type.args
         type_arg = get_proper_type(self.api.analyze_type(args[0]))
 
-        if not isinstance(type_arg, Instance):
-            return unbound_type
+        is_type: bool = False
+        if isinstance(type_arg, TypeType):
+            is_type = True
+            type_arg = type_arg.item
 
-        concrete = tuple(
-            self.store.retrieve_concrete_children_types(
-                type_arg.type, self.lookup_info, self.sem_api.named_type_or_none
+        if isinstance(type_arg, AnyType):
+            self.api.fail("Tried to use concrete annotations on a typing.Any", unbound_type)
+            return False, None
+
+        if not isinstance(type_arg, Instance | UnionType):
+            return False, None
+
+        if isinstance(type_arg, Instance):
+            type_arg = UnionType((type_arg,))
+
+        all_types = list(self._flatten_union(type_arg))
+        all_instances: list[Instance] = []
+        not_all_instances: bool = False
+        for item in all_types:
+            if not isinstance(item, Instance):
+                self.sem_api.fail(
+                    f"Expected to operate on specific classes, got a {item.__class__.__name__}: {item}",
+                    unbound_type,
+                )
+                not_all_instances = True
+            else:
+                all_instances.append(item)
+
+        if not_all_instances:
+            return False, None
+
+        if not expand:
+            return is_type, tuple(all_instances)
+
+        concrete: list[Instance] = []
+        names = ", ".join([item.type.fullname for item in all_instances])
+
+        for item in all_instances:
+            concrete.extend(
+                self.store.retrieve_concrete_children_types(
+                    item.type, self.lookup_info, self.sem_api.named_type_or_none
+                )
             )
-        )
+
         if not concrete:
             if self.sem_api.final_iteration:
-                self.api.fail(
-                    f"No concrete models found for {type_arg.type.fullname}", unbound_type
-                )
-                return AnyType(TypeOfAny.from_error)
+                self.api.fail(f"No concrete models found for {names}", unbound_type)
+                return False, None
             else:
                 self.sem_api.defer()
-                return unbound_type
+                return False, None
 
-        return UnionType(concrete)
+        return is_type, tuple(concrete)
+
+    def _make_union(self, is_type: bool, instances: Sequence[Instance]) -> UnionType | TypeType:
+        made = UnionType(instances)
+        if is_type:
+            return TypeType(made)
+        else:
+            return made
+
+    def find_concrete_models(self, unbound_type: UnboundType) -> MypyType:
+        is_type, concrete = self._analyze_first_type_arg(unbound_type)
+        if concrete is None:
+            return unbound_type
+
+        return self._make_union(is_type, concrete)
 
     def find_concrete_querysets(self, unbound_type: UnboundType) -> MypyType:
-        args = unbound_type.args
-        type_arg = get_proper_type(self.api.analyze_type(args[0]))
-
-        if not isinstance(type_arg, Instance):
-            return UnionType(())
-
-        concrete = tuple(
-            self.store.retrieve_concrete_children_types(
-                type_arg.type, self.lookup_info, self.sem_api.named_type_or_none
-            )
-        )
-        if not concrete:
-            self.api.fail(f"No concrete models found for {type_arg.type.fullname}", unbound_type)
-            return AnyType(TypeOfAny.from_error)
+        is_type, concrete = self._analyze_first_type_arg(unbound_type)
+        if concrete is None:
+            return unbound_type
 
         try:
             querysets = tuple(self.store.realise_querysets(UnionType(concrete), self.lookup_info))
@@ -74,25 +123,15 @@ class TypeAnalyzing:
             self.api.fail("Union must be of instances of models", unbound_type)
             return AnyType(TypeOfAny.from_error)
         else:
-            return UnionType(querysets)
+            return self._make_union(is_type, querysets)
 
     def find_default_queryset(self, unbound_type: UnboundType) -> MypyType:
-        args = unbound_type.args
-        type_arg = get_proper_type(self.api.analyze_type(args[0]))
-
-        if isinstance(type_arg, AnyType):
-            self.api.fail("Can't get default query set for Any", unbound_type)
-            return unbound_type
-
-        if isinstance(type_arg, TypeVarType):
-            return unbound_type
-
-        if not isinstance(type_arg, Instance | UnionType):
-            self.api.fail("Default queryset needs a class to find for", unbound_type)
+        is_type, concrete = self._analyze_first_type_arg(unbound_type, expand=False)
+        if concrete is None:
             return unbound_type
 
         try:
-            querysets = tuple(self.store.realise_querysets(type_arg, self.lookup_info))
+            querysets = tuple(self.store.realise_querysets(UnionType(concrete), self.lookup_info))
         except _store.RestartDmypy as err:
             self.api.fail(f"You probably need to restart dmypy: {err}", unbound_type)
             return AnyType(TypeOfAny.from_error)
@@ -100,7 +139,7 @@ class TypeAnalyzing:
             self.api.fail("Union must be of instances of models", unbound_type)
             return unbound_type
         else:
-            return UnionType(querysets)
+            return self._make_union(is_type, querysets)
 
     def lookup_info(self, fullname: str) -> TypeInfo | None:
         instance = self.sem_api.named_type_or_none(fullname)

--- a/extended_mypy_django_plugin/plugin/actions/_type_analyze.py
+++ b/extended_mypy_django_plugin/plugin/actions/_type_analyze.py
@@ -95,8 +95,15 @@ class TypeAnalyzing:
 
         return is_type, tuple(concrete)
 
-    def _make_union(self, is_type: bool, instances: Sequence[Instance]) -> UnionType | TypeType:
-        made = UnionType(instances)
+    def _make_union(
+        self, is_type: bool, instances: Sequence[Instance]
+    ) -> UnionType | Instance | TypeType:
+        made: UnionType | TypeType | Instance
+        if len(instances) == 1:
+            made = instances[0]
+        else:
+            made = UnionType(instances)
+
         if is_type:
             return TypeType(made)
         else:

--- a/tests/test_concrete_annotations.py
+++ b/tests/test_concrete_annotations.py
@@ -33,6 +33,15 @@ class TestConcreteAnnotations:
                 assert check_instance_with_type_guard(instance)
                 reveal_type(instance)
 
+                children: Concrete[Parent]
+                reveal_type(children)
+
+                children_qs1: ConcreteQuerySet[Parent]
+                reveal_type(children_qs1)
+
+                children_qs2: DefaultQuerySet[Parent]
+                reveal_type(children_qs2)
+
                 child: Concrete[Child1]
                 reveal_type(child)
 
@@ -69,22 +78,34 @@ class TestConcreteAnnotations:
                 ),
                 (
                     27,
-                    "Union[myapp.models.Child1]",
+                    "Union[myapp.models.Child1, myapp.models.Child2, myapp.models.Child3, myapp2.models.ChildOther]",
                 ),
                 (
                     30,
-                    "Union[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1]]",
+                    "Union[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1], myapp.models.Child2QuerySet, django.db.models.query.QuerySet[myapp.models.Child3, myapp.models.Child3], django.db.models.query.QuerySet[myapp2.models.ChildOther, myapp2.models.ChildOther]]",
                 ),
                 (
                     33,
-                    "Union[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1]]",
+                    "Union[django.db.models.query.QuerySet[myapp.models.Parent, myapp.models.Parent]]",
                 ),
                 (
                     36,
-                    "Union[myapp.models.Child2QuerySet]",
+                    "Union[myapp.models.Child1]",
                 ),
                 (
                     39,
+                    "Union[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1]]",
+                ),
+                (
+                    42,
+                    "Union[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1]]",
+                ),
+                (
+                    45,
+                    "Union[myapp.models.Child2QuerySet]",
+                ),
+                (
+                    48,
                     "Union[myapp.models.Child2QuerySet]",
                 ),
             ]

--- a/tests/test_concrete_annotations.py
+++ b/tests/test_concrete_annotations.py
@@ -42,22 +42,22 @@ class TestConcreteAnnotations:
                 # ^ REVEAL children_qs1 ^ Union[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1], myapp.models.Child2QuerySet, django.db.models.query.QuerySet[myapp.models.Child3, myapp.models.Child3], django.db.models.query.QuerySet[myapp2.models.ChildOther, myapp2.models.ChildOther]]
 
                 children_qs2: DefaultQuerySet[Parent]
-                # ^ REVEAL children_qs2 ^ Union[django.db.models.query.QuerySet[myapp.models.Parent, myapp.models.Parent]]
+                # ^ REVEAL children_qs2 ^ django.db.models.query.QuerySet[myapp.models.Parent, myapp.models.Parent]
 
                 child: Concrete[Child1]
-                # ^ REVEAL child ^ Union[myapp.models.Child1]
+                # ^ REVEAL child ^ myapp.models.Child1
 
                 child1_qs1: ConcreteQuerySet[Child1]
-                # ^ REVEAL child1_qs1 ^ Union[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1]]
+                # ^ REVEAL child1_qs1 ^ django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1]
 
                 child1_qs2: DefaultQuerySet[Child1]
-                # ^ REVEAL child1_qs2 ^ Union[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1]]
+                # ^ REVEAL child1_qs2 ^ django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1]
 
                 child2_qs1: ConcreteQuerySet[Child2]
-                # ^ REVEAL child2_qs1 ^ Union[myapp.models.Child2QuerySet]
+                # ^ REVEAL child2_qs1 ^ myapp.models.Child2QuerySet
 
                 child2_qs2: DefaultQuerySet[Child2]
-                # ^ REVEAL child2_qs2 ^ Union[myapp.models.Child2QuerySet]
+                # ^ REVEAL child2_qs2 ^ myapp.models.Child2QuerySet
 
                 t1_children: type[Concrete[Parent]]
                 # ^ REVEAL t1_children ^ Union[type[myapp.models.Child1], type[myapp.models.Child2], type[myapp.models.Child3], type[myapp2.models.ChildOther]]
@@ -90,22 +90,22 @@ class TestConcreteAnnotations:
                 # ^ REVEAL t2_children_qs1 ^ type[Union[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1], myapp.models.Child2QuerySet, django.db.models.query.QuerySet[myapp.models.Child3, myapp.models.Child3], django.db.models.query.QuerySet[myapp2.models.ChildOther, myapp2.models.ChildOther]]]
 
                 t2_children_qs2: DefaultQuerySet[type[Parent]]
-                # ^ REVEAL t2_children_qs2 ^ type[Union[django.db.models.query.QuerySet[myapp.models.Parent, myapp.models.Parent]]]
+                # ^ REVEAL t2_children_qs2 ^ type[django.db.models.query.QuerySet[myapp.models.Parent, myapp.models.Parent]]
 
                 t2_child: Concrete[type[Child1]]
-                # ^ REVEAL t2_child ^ type[Union[myapp.models.Child1]]
+                # ^ REVEAL t2_child ^ type[myapp.models.Child1]
 
                 t2_child1_qs1: ConcreteQuerySet[type[Child1]]
-                # ^ REVEAL t2_child1_qs1 ^ type[Union[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1]]]
+                # ^ REVEAL t2_child1_qs1 ^ type[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1]]
 
                 t2_child1_qs2: DefaultQuerySet[type[Child1]]
-                # ^ REVEAL t2_child1_qs2 ^ type[Union[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1]]]
+                # ^ REVEAL t2_child1_qs2 ^ type[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1]]
 
                 t2_child2_qs1: ConcreteQuerySet[type[Child2]]
-                # ^ REVEAL t2_child2_qs1 ^ type[Union[myapp.models.Child2QuerySet]]
+                # ^ REVEAL t2_child2_qs1 ^ type[myapp.models.Child2QuerySet]
 
                 t2_child2_qs2: DefaultQuerySet[type[Child2]]
-                # ^ REVEAL t2_child2_qs2 ^ type[Union[myapp.models.Child2QuerySet]]
+                # ^ REVEAL t2_child2_qs2 ^ type[myapp.models.Child2QuerySet]
                 """,
             )
 
@@ -319,8 +319,8 @@ class TestConcreteAnnotations:
 
             (
                 expected.on("main.py")
-                .add_revealed_type(6, "Union[follower1.models.follower1.Follower1]")
-                .add_revealed_type(9, "Union[follower1.models.follower1.Follower1QuerySet]")
+                .add_revealed_type(6, "follower1.models.follower1.Follower1")
+                .add_revealed_type(9, "follower1.models.follower1.Follower1QuerySet")
                 .add_error(
                     10,
                     "misc",
@@ -449,8 +449,8 @@ class TestConcreteAnnotations:
 
             (
                 expected.on("main.py")
-                .add_revealed_type(6, "Union[follower1.models.follower1.Follower1]")
-                .add_revealed_type(9, "Union[follower1.models.follower1.Follower1QuerySet]")
+                .add_revealed_type(6, "follower1.models.follower1.Follower1")
+                .add_revealed_type(9, "follower1.models.follower1.Follower1QuerySet")
                 .add_error(
                     10,
                     "misc",

--- a/tests/test_concrete_annotations.py
+++ b/tests/test_concrete_annotations.py
@@ -56,6 +56,54 @@ class TestConcreteAnnotations:
 
                 child2_qs2: DefaultQuerySet[Child2]
                 reveal_type(child2_qs2)
+
+                t1_children: type[Concrete[Parent]]
+                reveal_type(t1_children)
+
+                t1_children_qs1: type[ConcreteQuerySet[Parent]]
+                reveal_type(t1_children_qs1)
+
+                t1_children_qs2: type[DefaultQuerySet[Parent]]
+                reveal_type(t1_children_qs2)
+
+                t1_child: type[Concrete[Child1]]
+                reveal_type(t1_child)
+
+                t1_child1_qs1: type[ConcreteQuerySet[Child1]]
+                reveal_type(t1_child1_qs1)
+
+                t1_child1_qs2: type[DefaultQuerySet[Child1]]
+                reveal_type(t1_child1_qs2)
+
+                t1_child2_qs1: type[ConcreteQuerySet[Child2]]
+                reveal_type(t1_child2_qs1)
+
+                t1_child2_qs2: type[DefaultQuerySet[Child2]]
+                reveal_type(t1_child2_qs2)
+
+                t2_children: Concrete[type[Parent]]
+                reveal_type(t2_children)
+
+                t2_children_qs1: ConcreteQuerySet[type[Parent]]
+                reveal_type(t2_children_qs1)
+
+                t2_children_qs2: DefaultQuerySet[type[Parent]]
+                reveal_type(t2_children_qs2)
+
+                t2_child: Concrete[type[Child1]]
+                reveal_type(t2_child)
+
+                t2_child1_qs1: ConcreteQuerySet[type[Child1]]
+                reveal_type(t2_child1_qs1)
+
+                t2_child1_qs2: DefaultQuerySet[type[Child1]]
+                reveal_type(t2_child1_qs2)
+
+                t2_child2_qs1: ConcreteQuerySet[type[Child2]]
+                reveal_type(t2_child2_qs1)
+
+                t2_child2_qs2: DefaultQuerySet[type[Child2]]
+                reveal_type(t2_child2_qs2)
                 """,
             )
 
@@ -107,6 +155,70 @@ class TestConcreteAnnotations:
                 (
                     48,
                     "Union[myapp.models.Child2QuerySet]",
+                ),
+                (
+                    51,
+                    "Union[type[myapp.models.Child1], type[myapp.models.Child2], type[myapp.models.Child3], type[myapp2.models.ChildOther]]",
+                ),
+                (
+                    54,
+                    "Union[type[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1]], type[myapp.models.Child2QuerySet], type[django.db.models.query.QuerySet[myapp.models.Child3, myapp.models.Child3]], type[django.db.models.query.QuerySet[myapp2.models.ChildOther, myapp2.models.ChildOther]]]",
+                ),
+                (
+                    57,
+                    "type[django.db.models.query.QuerySet[myapp.models.Parent, myapp.models.Parent]]",
+                ),
+                (
+                    60,
+                    "type[myapp.models.Child1]",
+                ),
+                (
+                    63,
+                    "type[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1]]",
+                ),
+                (
+                    66,
+                    "type[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1]]",
+                ),
+                (
+                    69,
+                    "type[myapp.models.Child2QuerySet]",
+                ),
+                (
+                    72,
+                    "type[myapp.models.Child2QuerySet]",
+                ),
+                (
+                    75,
+                    "type[Union[myapp.models.Child1, myapp.models.Child2, myapp.models.Child3, myapp2.models.ChildOther]]",
+                ),
+                (
+                    78,
+                    "type[Union[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1], myapp.models.Child2QuerySet, django.db.models.query.QuerySet[myapp.models.Child3, myapp.models.Child3], django.db.models.query.QuerySet[myapp2.models.ChildOther, myapp2.models.ChildOther]]]",
+                ),
+                (
+                    81,
+                    "type[Union[django.db.models.query.QuerySet[myapp.models.Parent, myapp.models.Parent]]]",
+                ),
+                (
+                    84,
+                    "type[Union[myapp.models.Child1]]",
+                ),
+                (
+                    87,
+                    "type[Union[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1]]]",
+                ),
+                (
+                    90,
+                    "type[Union[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1]]]",
+                ),
+                (
+                    93,
+                    "type[Union[myapp.models.Child2QuerySet]]",
+                ),
+                (
+                    96,
+                    "type[Union[myapp.models.Child2QuerySet]]",
                 ),
             ]
 

--- a/tests/test_concrete_annotations.py
+++ b/tests/test_concrete_annotations.py
@@ -7,10 +7,10 @@ class TestConcreteAnnotations:
         def _(expected: OutputBuilder) -> None:
             scenario.make_file_with_reveals(
                 expected,
-                28,
+                19,
                 "main.py",
                 """
-                from extended_mypy_django_plugin import Concrete, ConcreteQuerySet, DefaultQuerySet
+                from extended_mypy_django_plugin import Concrete, DefaultQuerySet
                 from typing import cast, TypeGuard
 
                 from myapp.models import Parent, Child1, Child2
@@ -24,7 +24,7 @@ class TestConcreteAnnotations:
                 models: Concrete[Parent]
                 # ^ REVEAL models ^ Union[myapp.models.Child1, myapp.models.Child2, myapp.models.Child3, myapp2.models.ChildOther]
 
-                qs: ConcreteQuerySet[Parent]
+                qs: DefaultQuerySet[Parent]
                 # ^ REVEAL qs ^ Union[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1], myapp.models.Child2QuerySet, django.db.models.query.QuerySet[myapp.models.Child3, myapp.models.Child3], django.db.models.query.QuerySet[myapp2.models.ChildOther, myapp2.models.ChildOther]]
 
                 cls: type[Parent] = Child1
@@ -38,74 +38,47 @@ class TestConcreteAnnotations:
                 children: Concrete[Parent]
                 # ^ REVEAL children ^ Union[myapp.models.Child1, myapp.models.Child2, myapp.models.Child3, myapp2.models.ChildOther]
 
-                children_qs1: ConcreteQuerySet[Parent]
-                # ^ REVEAL children_qs1 ^ Union[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1], myapp.models.Child2QuerySet, django.db.models.query.QuerySet[myapp.models.Child3, myapp.models.Child3], django.db.models.query.QuerySet[myapp2.models.ChildOther, myapp2.models.ChildOther]]
-
-                children_qs2: DefaultQuerySet[Parent]
-                # ^ REVEAL children_qs2 ^ django.db.models.query.QuerySet[myapp.models.Parent, myapp.models.Parent]
+                children_qs: DefaultQuerySet[Parent]
+                # ^ REVEAL children_qs ^ Union[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1], myapp.models.Child2QuerySet, django.db.models.query.QuerySet[myapp.models.Child3, myapp.models.Child3], django.db.models.query.QuerySet[myapp2.models.ChildOther, myapp2.models.ChildOther]]
 
                 child: Concrete[Child1]
                 # ^ REVEAL child ^ myapp.models.Child1
 
-                child1_qs1: ConcreteQuerySet[Child1]
-                # ^ REVEAL child1_qs1 ^ django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1]
+                child1_qs: DefaultQuerySet[Child1]
+                # ^ REVEAL child1_qs ^ django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1]
 
-                child1_qs2: DefaultQuerySet[Child1]
-                # ^ REVEAL child1_qs2 ^ django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1]
-
-                child2_qs1: ConcreteQuerySet[Child2]
-                # ^ REVEAL child2_qs1 ^ myapp.models.Child2QuerySet
-
-                child2_qs2: DefaultQuerySet[Child2]
-                # ^ REVEAL child2_qs2 ^ myapp.models.Child2QuerySet
+                child2_qs: DefaultQuerySet[Child2]
+                # ^ REVEAL child2_qs ^ myapp.models.Child2QuerySet
 
                 t1_children: type[Concrete[Parent]]
                 # ^ REVEAL t1_children ^ Union[type[myapp.models.Child1], type[myapp.models.Child2], type[myapp.models.Child3], type[myapp2.models.ChildOther]]
 
-                t1_children_qs1: type[ConcreteQuerySet[Parent]]
-                # ^ REVEAL t1_children_qs1 ^ Union[type[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1]], type[myapp.models.Child2QuerySet], type[django.db.models.query.QuerySet[myapp.models.Child3, myapp.models.Child3]], type[django.db.models.query.QuerySet[myapp2.models.ChildOther, myapp2.models.ChildOther]]]
-
-                t1_children_qs2: type[DefaultQuerySet[Parent]]
-                # ^ REVEAL t1_children_qs2 ^ type[django.db.models.query.QuerySet[myapp.models.Parent, myapp.models.Parent]]
+                t1_children_qs: type[DefaultQuerySet[Parent]]
+                # ^ REVEAL t1_children_qs ^ Union[type[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1]], type[myapp.models.Child2QuerySet], type[django.db.models.query.QuerySet[myapp.models.Child3, myapp.models.Child3]], type[django.db.models.query.QuerySet[myapp2.models.ChildOther, myapp2.models.ChildOther]]]
 
                 t1_child: type[Concrete[Child1]]
                 # ^ REVEAL t1_child ^ type[myapp.models.Child1]
 
-                t1_child1_qs1: type[ConcreteQuerySet[Child1]]
-                # ^ REVEAL t1_child1_qs1 ^ type[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1]]
+                t1_child1_qs: type[DefaultQuerySet[Child1]]
+                # ^ REVEAL t1_child1_qs ^ type[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1]]
 
-                t1_child1_qs2: type[DefaultQuerySet[Child1]]
-                # ^ REVEAL t1_child1_qs2 ^ type[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1]]
-
-                t1_child2_qs1: type[ConcreteQuerySet[Child2]]
-                # ^ REVEAL t1_child2_qs1 ^ type[myapp.models.Child2QuerySet]
-
-                t1_child2_qs2: type[DefaultQuerySet[Child2]]
-                # ^ REVEAL t1_child2_qs2 ^ type[myapp.models.Child2QuerySet]
+                t1_child2_qs: type[DefaultQuerySet[Child2]]
+                # ^ REVEAL t1_child2_qs ^ type[myapp.models.Child2QuerySet]
 
                 t2_children: Concrete[type[Parent]]
                 # ^ REVEAL t2_children ^ Union[type[myapp.models.Child1], type[myapp.models.Child2], type[myapp.models.Child3], type[myapp2.models.ChildOther]]
 
-                t2_children_qs1: ConcreteQuerySet[type[Parent]]
-                # ^ REVEAL t2_children_qs1 ^ Union[type[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1]], type[myapp.models.Child2QuerySet], type[django.db.models.query.QuerySet[myapp.models.Child3, myapp.models.Child3]], type[django.db.models.query.QuerySet[myapp2.models.ChildOther, myapp2.models.ChildOther]]]
-
-                t2_children_qs2: DefaultQuerySet[type[Parent]]
-                # ^ REVEAL t2_children_qs2 ^ type[django.db.models.query.QuerySet[myapp.models.Parent, myapp.models.Parent]]
+                t2_children_qs: DefaultQuerySet[type[Parent]]
+                # ^ REVEAL t2_children_qs ^ Union[type[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1]], type[myapp.models.Child2QuerySet], type[django.db.models.query.QuerySet[myapp.models.Child3, myapp.models.Child3]], type[django.db.models.query.QuerySet[myapp2.models.ChildOther, myapp2.models.ChildOther]]]
 
                 t2_child: Concrete[type[Child1]]
                 # ^ REVEAL t2_child ^ type[myapp.models.Child1]
 
-                t2_child1_qs1: ConcreteQuerySet[type[Child1]]
-                # ^ REVEAL t2_child1_qs1 ^ type[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1]]
+                t2_child1_qs: DefaultQuerySet[type[Child1]]
+                # ^ REVEAL t2_child1_qs ^ type[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1]]
 
-                t2_child1_qs2: DefaultQuerySet[type[Child1]]
-                # ^ REVEAL t2_child1_qs2 ^ type[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1]]
-
-                t2_child2_qs1: ConcreteQuerySet[type[Child2]]
-                # ^ REVEAL t2_child2_qs1 ^ type[myapp.models.Child2QuerySet]
-
-                t2_child2_qs2: DefaultQuerySet[type[Child2]]
-                # ^ REVEAL t2_child2_qs2 ^ type[myapp.models.Child2QuerySet]
+                t2_child2_qs: DefaultQuerySet[type[Child2]]
+                # ^ REVEAL t2_child2_qs ^ type[myapp.models.Child2QuerySet]
                 """,
             )
 
@@ -117,14 +90,14 @@ class TestConcreteAnnotations:
             scenario.make_file(
                 "main.py",
                 """
-                from extended_mypy_django_plugin import Concrete, ConcreteQuerySet, DefaultQuerySet
+                from extended_mypy_django_plugin import Concrete, DefaultQuerySet
 
                 from myapp.models import Parent
 
                 models: Concrete[Parent]
                 reveal_type(models)
 
-                qs: ConcreteQuerySet[Parent]
+                qs: DefaultQuerySet[Parent]
                 reveal_type(qs)
                 """,
             )
@@ -167,14 +140,14 @@ class TestConcreteAnnotations:
             scenario.make_file(
                 "main.py",
                 """
-                from extended_mypy_django_plugin import Concrete, ConcreteQuerySet, DefaultQuerySet
+                from extended_mypy_django_plugin import Concrete, DefaultQuerySet
 
                 from myapp.models import Parent
 
                 model: Concrete[Parent]
                 model.concrete_from_myapp
 
-                qs: ConcreteQuerySet[Parent]
+                qs: DefaultQuerySet[Parent]
                 qs.values("concrete_from_myapp")
                 """,
             )
@@ -205,14 +178,14 @@ class TestConcreteAnnotations:
             scenario.make_file(
                 "main.py",
                 """
-                from extended_mypy_django_plugin import Concrete, ConcreteQuerySet, DefaultQuerySet
+                from extended_mypy_django_plugin import Concrete, DefaultQuerySet
 
                 from myapp.models import Parent
 
                 models: Concrete[Parent]
                 reveal_type(models)
 
-                qs: ConcreteQuerySet[Parent]
+                qs: DefaultQuerySet[Parent]
                 qs.values("concrete_from_myapp")
                 """,
             )
@@ -254,14 +227,14 @@ class TestConcreteAnnotations:
             scenario.make_file(
                 "main.py",
                 """
-                from extended_mypy_django_plugin import Concrete, ConcreteQuerySet, DefaultQuerySet
+                from extended_mypy_django_plugin import Concrete, DefaultQuerySet
 
                 from myapp.models import Parent
 
                 models: Concrete[Parent]
                 models.two
 
-                qs: ConcreteQuerySet[Parent]
+                qs: DefaultQuerySet[Parent]
                 qs.values("two")
                 """,
             )
@@ -304,14 +277,14 @@ class TestConcreteAnnotations:
             scenario.make_file(
                 "main.py",
                 """
-                from extended_mypy_django_plugin import Concrete, ConcreteQuerySet, DefaultQuerySet
+                from extended_mypy_django_plugin import Concrete, DefaultQuerySet
 
                 from leader.models import Leader
 
                 models: Concrete[Leader]
                 reveal_type(models)
 
-                qs: ConcreteQuerySet[Leader]
+                qs: DefaultQuerySet[Leader]
                 reveal_type(qs)
                 qs.good_ones().values("nup")
                 """,
@@ -434,14 +407,14 @@ class TestConcreteAnnotations:
             scenario.make_file(
                 "main.py",
                 """
-                from extended_mypy_django_plugin import Concrete, ConcreteQuerySet, DefaultQuerySet
+                from extended_mypy_django_plugin import Concrete, DefaultQuerySet
 
                 from leader.models import Leader
 
                 models: Concrete[Leader]
                 reveal_type(models)
 
-                qs: ConcreteQuerySet[Leader]
+                qs: DefaultQuerySet[Leader]
                 reveal_type(qs)
                 qs.good_ones().values("nup")
                 """,

--- a/tests/test_concrete_annotations.py
+++ b/tests/test_concrete_annotations.py
@@ -84,10 +84,10 @@ class TestConcreteAnnotations:
                 # ^ REVEAL t1_child2_qs2 ^ type[myapp.models.Child2QuerySet]
 
                 t2_children: Concrete[type[Parent]]
-                # ^ REVEAL t2_children ^ type[Union[myapp.models.Child1, myapp.models.Child2, myapp.models.Child3, myapp2.models.ChildOther]]
+                # ^ REVEAL t2_children ^ Union[type[myapp.models.Child1], type[myapp.models.Child2], type[myapp.models.Child3], type[myapp2.models.ChildOther]]
 
                 t2_children_qs1: ConcreteQuerySet[type[Parent]]
-                # ^ REVEAL t2_children_qs1 ^ type[Union[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1], myapp.models.Child2QuerySet, django.db.models.query.QuerySet[myapp.models.Child3, myapp.models.Child3], django.db.models.query.QuerySet[myapp2.models.ChildOther, myapp2.models.ChildOther]]]
+                # ^ REVEAL t2_children_qs1 ^ Union[type[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1]], type[myapp.models.Child2QuerySet], type[django.db.models.query.QuerySet[myapp.models.Child3, myapp.models.Child3]], type[django.db.models.query.QuerySet[myapp2.models.ChildOther, myapp2.models.ChildOther]]]
 
                 t2_children_qs2: DefaultQuerySet[type[Parent]]
                 # ^ REVEAL t2_children_qs2 ^ type[django.db.models.query.QuerySet[myapp.models.Parent, myapp.models.Parent]]

--- a/tests/test_concrete_annotations.py
+++ b/tests/test_concrete_annotations.py
@@ -5,7 +5,9 @@ class TestConcreteAnnotations:
     def test_simple_annotation(self, scenario: Scenario) -> None:
         @scenario.run_and_check_mypy_after
         def _(expected: OutputBuilder) -> None:
-            scenario.make_file(
+            scenario.make_file_with_reveals(
+                expected,
+                28,
                 "main.py",
                 """
                 from extended_mypy_django_plugin import Concrete, ConcreteQuerySet, DefaultQuerySet
@@ -13,218 +15,99 @@ class TestConcreteAnnotations:
 
                 from myapp.models import Parent, Child1, Child2
 
-                models: Concrete[Parent]
-                reveal_type(models)
-
-                qs: ConcreteQuerySet[Parent]
-                reveal_type(qs)
-
                 def check_cls_with_type_guard(cls: type[Parent]) -> TypeGuard[type[Concrete[Parent]]]:
                     return True
 
                 def check_instance_with_type_guard(cls: Parent) -> TypeGuard[Concrete[Parent]]:
                     return True
 
+                models: Concrete[Parent]
+                # ^ REVEAL models ^ Union[myapp.models.Child1, myapp.models.Child2, myapp.models.Child3, myapp2.models.ChildOther]
+
+                qs: ConcreteQuerySet[Parent]
+                # ^ REVEAL qs ^ Union[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1], myapp.models.Child2QuerySet, django.db.models.query.QuerySet[myapp.models.Child3, myapp.models.Child3], django.db.models.query.QuerySet[myapp2.models.ChildOther, myapp2.models.ChildOther]]
+
                 cls: type[Parent] = Child1
                 assert check_cls_with_type_guard(cls)
-                reveal_type(cls)
+                # ^ REVEAL cls ^ Union[type[myapp.models.Child1], type[myapp.models.Child2], type[myapp.models.Child3], type[myapp2.models.ChildOther]]
 
                 instance: Parent = cast(Child1, None)
                 assert check_instance_with_type_guard(instance)
-                reveal_type(instance)
+                # ^ REVEAL instance ^ Union[myapp.models.Child1, myapp.models.Child2, myapp.models.Child3, myapp2.models.ChildOther]
 
                 children: Concrete[Parent]
-                reveal_type(children)
+                # ^ REVEAL children ^ Union[myapp.models.Child1, myapp.models.Child2, myapp.models.Child3, myapp2.models.ChildOther]
 
                 children_qs1: ConcreteQuerySet[Parent]
-                reveal_type(children_qs1)
+                # ^ REVEAL children_qs1 ^ Union[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1], myapp.models.Child2QuerySet, django.db.models.query.QuerySet[myapp.models.Child3, myapp.models.Child3], django.db.models.query.QuerySet[myapp2.models.ChildOther, myapp2.models.ChildOther]]
 
                 children_qs2: DefaultQuerySet[Parent]
-                reveal_type(children_qs2)
+                # ^ REVEAL children_qs2 ^ Union[django.db.models.query.QuerySet[myapp.models.Parent, myapp.models.Parent]]
 
                 child: Concrete[Child1]
-                reveal_type(child)
+                # ^ REVEAL child ^ Union[myapp.models.Child1]
 
                 child1_qs1: ConcreteQuerySet[Child1]
-                reveal_type(child1_qs1)
+                # ^ REVEAL child1_qs1 ^ Union[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1]]
 
                 child1_qs2: DefaultQuerySet[Child1]
-                reveal_type(child1_qs2)
+                # ^ REVEAL child1_qs2 ^ Union[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1]]
 
                 child2_qs1: ConcreteQuerySet[Child2]
-                reveal_type(child2_qs1)
+                # ^ REVEAL child2_qs1 ^ Union[myapp.models.Child2QuerySet]
 
                 child2_qs2: DefaultQuerySet[Child2]
-                reveal_type(child2_qs2)
+                # ^ REVEAL child2_qs2 ^ Union[myapp.models.Child2QuerySet]
 
                 t1_children: type[Concrete[Parent]]
-                reveal_type(t1_children)
+                # ^ REVEAL t1_children ^ Union[type[myapp.models.Child1], type[myapp.models.Child2], type[myapp.models.Child3], type[myapp2.models.ChildOther]]
 
                 t1_children_qs1: type[ConcreteQuerySet[Parent]]
-                reveal_type(t1_children_qs1)
+                # ^ REVEAL t1_children_qs1 ^ Union[type[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1]], type[myapp.models.Child2QuerySet], type[django.db.models.query.QuerySet[myapp.models.Child3, myapp.models.Child3]], type[django.db.models.query.QuerySet[myapp2.models.ChildOther, myapp2.models.ChildOther]]]
 
                 t1_children_qs2: type[DefaultQuerySet[Parent]]
-                reveal_type(t1_children_qs2)
+                # ^ REVEAL t1_children_qs2 ^ type[django.db.models.query.QuerySet[myapp.models.Parent, myapp.models.Parent]]
 
                 t1_child: type[Concrete[Child1]]
-                reveal_type(t1_child)
+                # ^ REVEAL t1_child ^ type[myapp.models.Child1]
 
                 t1_child1_qs1: type[ConcreteQuerySet[Child1]]
-                reveal_type(t1_child1_qs1)
+                # ^ REVEAL t1_child1_qs1 ^ type[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1]]
 
                 t1_child1_qs2: type[DefaultQuerySet[Child1]]
-                reveal_type(t1_child1_qs2)
+                # ^ REVEAL t1_child1_qs2 ^ type[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1]]
 
                 t1_child2_qs1: type[ConcreteQuerySet[Child2]]
-                reveal_type(t1_child2_qs1)
+                # ^ REVEAL t1_child2_qs1 ^ type[myapp.models.Child2QuerySet]
 
                 t1_child2_qs2: type[DefaultQuerySet[Child2]]
-                reveal_type(t1_child2_qs2)
+                # ^ REVEAL t1_child2_qs2 ^ type[myapp.models.Child2QuerySet]
 
                 t2_children: Concrete[type[Parent]]
-                reveal_type(t2_children)
+                # ^ REVEAL t2_children ^ type[Union[myapp.models.Child1, myapp.models.Child2, myapp.models.Child3, myapp2.models.ChildOther]]
 
                 t2_children_qs1: ConcreteQuerySet[type[Parent]]
-                reveal_type(t2_children_qs1)
+                # ^ REVEAL t2_children_qs1 ^ type[Union[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1], myapp.models.Child2QuerySet, django.db.models.query.QuerySet[myapp.models.Child3, myapp.models.Child3], django.db.models.query.QuerySet[myapp2.models.ChildOther, myapp2.models.ChildOther]]]
 
                 t2_children_qs2: DefaultQuerySet[type[Parent]]
-                reveal_type(t2_children_qs2)
+                # ^ REVEAL t2_children_qs2 ^ type[Union[django.db.models.query.QuerySet[myapp.models.Parent, myapp.models.Parent]]]
 
                 t2_child: Concrete[type[Child1]]
-                reveal_type(t2_child)
+                # ^ REVEAL t2_child ^ type[Union[myapp.models.Child1]]
 
                 t2_child1_qs1: ConcreteQuerySet[type[Child1]]
-                reveal_type(t2_child1_qs1)
+                # ^ REVEAL t2_child1_qs1 ^ type[Union[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1]]]
 
                 t2_child1_qs2: DefaultQuerySet[type[Child1]]
-                reveal_type(t2_child1_qs2)
+                # ^ REVEAL t2_child1_qs2 ^ type[Union[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1]]]
 
                 t2_child2_qs1: ConcreteQuerySet[type[Child2]]
-                reveal_type(t2_child2_qs1)
+                # ^ REVEAL t2_child2_qs1 ^ type[Union[myapp.models.Child2QuerySet]]
 
                 t2_child2_qs2: DefaultQuerySet[type[Child2]]
-                reveal_type(t2_child2_qs2)
+                # ^ REVEAL t2_child2_qs2 ^ type[Union[myapp.models.Child2QuerySet]]
                 """,
             )
-
-            revealed: list[tuple[int, str]] = [
-                (
-                    7,
-                    "Union[myapp.models.Child1, myapp.models.Child2, myapp.models.Child3, myapp2.models.ChildOther]",
-                ),
-                (
-                    10,
-                    "Union[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1], myapp.models.Child2QuerySet, django.db.models.query.QuerySet[myapp.models.Child3, myapp.models.Child3], django.db.models.query.QuerySet[myapp2.models.ChildOther, myapp2.models.ChildOther]]",
-                ),
-                (
-                    20,
-                    "Union[type[myapp.models.Child1], type[myapp.models.Child2], type[myapp.models.Child3], type[myapp2.models.ChildOther]]",
-                ),
-                (
-                    24,
-                    "Union[myapp.models.Child1, myapp.models.Child2, myapp.models.Child3, myapp2.models.ChildOther]",
-                ),
-                (
-                    27,
-                    "Union[myapp.models.Child1, myapp.models.Child2, myapp.models.Child3, myapp2.models.ChildOther]",
-                ),
-                (
-                    30,
-                    "Union[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1], myapp.models.Child2QuerySet, django.db.models.query.QuerySet[myapp.models.Child3, myapp.models.Child3], django.db.models.query.QuerySet[myapp2.models.ChildOther, myapp2.models.ChildOther]]",
-                ),
-                (
-                    33,
-                    "Union[django.db.models.query.QuerySet[myapp.models.Parent, myapp.models.Parent]]",
-                ),
-                (
-                    36,
-                    "Union[myapp.models.Child1]",
-                ),
-                (
-                    39,
-                    "Union[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1]]",
-                ),
-                (
-                    42,
-                    "Union[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1]]",
-                ),
-                (
-                    45,
-                    "Union[myapp.models.Child2QuerySet]",
-                ),
-                (
-                    48,
-                    "Union[myapp.models.Child2QuerySet]",
-                ),
-                (
-                    51,
-                    "Union[type[myapp.models.Child1], type[myapp.models.Child2], type[myapp.models.Child3], type[myapp2.models.ChildOther]]",
-                ),
-                (
-                    54,
-                    "Union[type[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1]], type[myapp.models.Child2QuerySet], type[django.db.models.query.QuerySet[myapp.models.Child3, myapp.models.Child3]], type[django.db.models.query.QuerySet[myapp2.models.ChildOther, myapp2.models.ChildOther]]]",
-                ),
-                (
-                    57,
-                    "type[django.db.models.query.QuerySet[myapp.models.Parent, myapp.models.Parent]]",
-                ),
-                (
-                    60,
-                    "type[myapp.models.Child1]",
-                ),
-                (
-                    63,
-                    "type[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1]]",
-                ),
-                (
-                    66,
-                    "type[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1]]",
-                ),
-                (
-                    69,
-                    "type[myapp.models.Child2QuerySet]",
-                ),
-                (
-                    72,
-                    "type[myapp.models.Child2QuerySet]",
-                ),
-                (
-                    75,
-                    "type[Union[myapp.models.Child1, myapp.models.Child2, myapp.models.Child3, myapp2.models.ChildOther]]",
-                ),
-                (
-                    78,
-                    "type[Union[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1], myapp.models.Child2QuerySet, django.db.models.query.QuerySet[myapp.models.Child3, myapp.models.Child3], django.db.models.query.QuerySet[myapp2.models.ChildOther, myapp2.models.ChildOther]]]",
-                ),
-                (
-                    81,
-                    "type[Union[django.db.models.query.QuerySet[myapp.models.Parent, myapp.models.Parent]]]",
-                ),
-                (
-                    84,
-                    "type[Union[myapp.models.Child1]]",
-                ),
-                (
-                    87,
-                    "type[Union[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1]]]",
-                ),
-                (
-                    90,
-                    "type[Union[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1]]]",
-                ),
-                (
-                    93,
-                    "type[Union[myapp.models.Child2QuerySet]]",
-                ),
-                (
-                    96,
-                    "type[Union[myapp.models.Child2QuerySet]]",
-                ),
-            ]
-
-            main_expections = expected.on("main.py")
-            for lnum, expectation in revealed:
-                main_expections.add_revealed_type(lnum, expectation)
 
     def test_sees_apps_removed_when_they_still_exist_but_no_longer_installed(
         self, scenario: Scenario

--- a/tests/test_concrete_annotations.py
+++ b/tests/test_concrete_annotations.py
@@ -50,45 +50,48 @@ class TestConcreteAnnotations:
                 """,
             )
 
-            (
-                expected.on("main.py")
-                .add_revealed_type(
+            revealed: list[tuple[int, str]] = [
+                (
                     7,
                     "Union[myapp.models.Child1, myapp.models.Child2, myapp.models.Child3, myapp2.models.ChildOther]",
-                )
-                .add_revealed_type(
+                ),
+                (
                     10,
                     "Union[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1], myapp.models.Child2QuerySet, django.db.models.query.QuerySet[myapp.models.Child3, myapp.models.Child3], django.db.models.query.QuerySet[myapp2.models.ChildOther, myapp2.models.ChildOther]]",
-                )
-                .add_revealed_type(
+                ),
+                (
                     20,
                     "Union[type[myapp.models.Child1], type[myapp.models.Child2], type[myapp.models.Child3], type[myapp2.models.ChildOther]]",
-                )
-                .add_revealed_type(
+                ),
+                (
                     24,
                     "Union[myapp.models.Child1, myapp.models.Child2, myapp.models.Child3, myapp2.models.ChildOther]",
-                )
-                .add_revealed_type(
+                ),
+                (
                     27,
                     "Union[myapp.models.Child1]",
-                )
-                .add_revealed_type(
+                ),
+                (
                     30,
                     "Union[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1]]",
-                )
-                .add_revealed_type(
+                ),
+                (
                     33,
                     "Union[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1]]",
-                )
-                .add_revealed_type(
+                ),
+                (
                     36,
                     "Union[myapp.models.Child2QuerySet]",
-                )
-                .add_revealed_type(
+                ),
+                (
                     39,
                     "Union[myapp.models.Child2QuerySet]",
-                )
-            )
+                ),
+            ]
+
+            main_expections = expected.on("main.py")
+            for lnum, expectation in revealed:
+                main_expections.add_revealed_type(lnum, expectation)
 
     def test_sees_apps_removed_when_they_still_exist_but_no_longer_installed(
         self, scenario: Scenario

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -16,7 +16,7 @@ class TestErrors:
 
                 from myapp.models import Child1, Parent
 
-                from extended_mypy_django_plugin import Concrete, ConcreteQuerySet, DefaultQuerySet
+                from extended_mypy_django_plugin import Concrete
 
                 T_Parent = TypeVar("T_Parent", bound=Parent)
 

--- a/tests/test_works.py
+++ b/tests/test_works.py
@@ -17,7 +17,7 @@ def test_works(scenario: Scenario) -> None:
      """
 
     main = """
-    from extended_mypy_django_plugin import Concrete, ConcreteQuerySet, DefaultQuerySet
+    from extended_mypy_django_plugin import Concrete, DefaultQuerySet
 
     from myapp.models import Parent, Child1, Child2
 
@@ -28,7 +28,7 @@ def test_works(scenario: Scenario) -> None:
         return child.objects.create()
 
 
-    def make_any_queryset(child: type[Concrete[Parent]]) -> ConcreteQuerySet[Parent]:
+    def make_any_queryset(child: type[Concrete[Parent]]) -> DefaultQuerySet[Parent]:
         return child.objects.all()
 
 


### PR DESCRIPTION
Prior to this doing `type[Concrete[Parent]]` would work but `Concrete[type[Parent]]` would not.

This change will fix that situation and ensure that the code doing those transformations is a bit more consistent.

Part of this also means that `ConcreteQuerySet` and `DefaultQuerySet` are effectively equivalent and so `ConcreteQuerySet` is removed in favour of always using `DefaultQuerySet` regardless of whether finding that for an abstract model, a concrete model, or a union.