### PR TITLE
Make it concrete annotations work with the Self type

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -13,6 +13,7 @@ Changelog
       better now and will do the right thing
     * When an annotation would transform into a Union of one item, now it becomes that one item
     * Removed ``ConcreteQuerySet`` and made ``DefaultQuerySet`` take on that functionality
+    * Concrete annotations now work with the Self type
 
 .. _release-0.5.3:
 


### PR DESCRIPTION
For this to work we have to do some manual searching for the method symbols when they appear on a parent class. We also need to map the Self type variable based on the type given to the `MethodContext`