### PR TITLE
Introduce Concrete.cast_as_concrete

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -14,6 +14,7 @@ Changelog
     * When an annotation would transform into a Union of one item, now it becomes that one item
     * Removed ``ConcreteQuerySet`` and made ``DefaultQuerySet`` take on that functionality
     * Concrete annotations now work with the Self type
+    * Implemented Concrete.cast_as_concrete
 
 .. _release-0.5.3:
 

--- a/extended_mypy_django_plugin/plugin/_plugin.py
+++ b/extended_mypy_django_plugin/plugin/_plugin.py
@@ -189,10 +189,14 @@ class ExtendedMypyStubs(main.NewSemanalDjangoPlugin):
         Then we turn that into::
 
             T_Child = TypeVar("T_Child", Child1, Child2, Child3)
+
+        For ``Concrete.cast_as_concrete`` we narrow the target variable to be the concrete equivalent
+        of the argument.
         """
 
         class KnownConcreteMethods(enum.Enum):
             type_var = "type_var"
+            cast_as_concrete = "cast_as_concrete"
 
         method_name: KnownConcreteMethods
 
@@ -213,6 +217,8 @@ class ExtendedMypyStubs(main.NewSemanalDjangoPlugin):
 
             if self.method_name is self.KnownConcreteMethods.type_var:
                 return sem_analyzing.transform_type_var_classmethod(ctx)
+            elif self.method_name is self.KnownConcreteMethods.cast_as_concrete:
+                return sem_analyzing.transform_cast_as_concrete(ctx)
             else:
                 assert_never(self.method_name)
 


### PR DESCRIPTION
This lets us easily create methods on an abstract method that only operate on Concrete descendants of that model.