### PR TITLE
Fix how type vars are resolved

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -15,6 +15,8 @@ Changelog
     * Removed ``ConcreteQuerySet`` and made ``DefaultQuerySet`` take on that functionality
     * Concrete annotations now work with the Self type
     * Implemented Concrete.cast_as_concrete
+    * Concrete.type_var can now take a forward reference to the model being represented
+    * Implemented more scenarios where Concrete.type_var may be used
 
 .. _release-0.5.3:
 

--- a/extended_mypy_django_plugin/annotations.py
+++ b/extended_mypy_django_plugin/annotations.py
@@ -105,7 +105,7 @@ class Concrete(Generic[T_Parent]):
         return found
 
     @classmethod
-    def type_var(cls, name: str, parent: type[models.Model]) -> TypeVar:
+    def type_var(cls, name: str, parent: type[models.Model] | str) -> TypeVar:
         """
         This returns an empty ``TypeVar`` at runtime, but the ``mypy`` plugin will
         recognise that this ``TypeVar`` represents a choice of all the concrete

--- a/extended_mypy_django_plugin/plugin/_plugin.py
+++ b/extended_mypy_django_plugin/plugin/_plugin.py
@@ -269,7 +269,7 @@ class ExtendedMypyStubs(main.NewSemanalDjangoPlugin):
 
         def extra_init(self) -> None:
             super().extra_init()
-            self.shared_logic = actions.SharedAnnotationHookLogic(
+            self.shared_logic = actions.SharedModifyReturnTypeLogic(
                 self.store,
                 fullname=self.fullname,
                 get_symbolnode_for_fullname=functools.partial(
@@ -308,7 +308,7 @@ class ExtendedMypyStubs(main.NewSemanalDjangoPlugin):
     ):
         def extra_init(self) -> None:
             super().extra_init()
-            self.shared_logic = actions.SharedSignatureHookLogic(
+            self.shared_logic = actions.SharedCheckTypeGuardsLogic(
                 self.store,
                 fullname=self.fullname,
                 get_symbolnode_for_fullname=functools.partial(
@@ -323,7 +323,7 @@ class ExtendedMypyStubs(main.NewSemanalDjangoPlugin):
         def run(self, ctx: MethodSigContext | FunctionSigContext) -> FunctionLike:
             result = self.shared_logic.run(ctx)
             if result is not None:
-                return ctx.default_signature.copy_modified(ret_type=result)
+                return result
 
             if self.super_hook is not None:
                 return self.super_hook(ctx)

--- a/extended_mypy_django_plugin/plugin/actions/__init__.py
+++ b/extended_mypy_django_plugin/plugin/actions/__init__.py
@@ -1,12 +1,12 @@
 from ._annotation_resolver import AnnotationResolver
 from ._sem_analyze import SemAnalyzing, TypeAnalyzer
-from ._type_checker import SharedAnnotationHookLogic, SharedSignatureHookLogic, TypeChecking
+from ._type_checker import SharedCheckTypeGuardsLogic, SharedModifyReturnTypeLogic, TypeChecking
 
 __all__ = [
     "SemAnalyzing",
     "TypeAnalyzer",
     "AnnotationResolver",
     "TypeChecking",
-    "SharedAnnotationHookLogic",
-    "SharedSignatureHookLogic",
+    "SharedCheckTypeGuardsLogic",
+    "SharedModifyReturnTypeLogic",
 ]

--- a/mypy.ini
+++ b/mypy.ini
@@ -10,6 +10,7 @@ exclude = (?x)(
     | ^tools/deps
     | ^example
     | ^scripts/myapp
+    | ^scripts/simple
     | ^scripts/leader
     | ^scripts/follower
     )

--- a/scripts/simple/apps.py
+++ b/scripts/simple/apps.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+
+
+class ExampleappConfig(AppConfig):
+    name = "simple"

--- a/scripts/simple/models.py
+++ b/scripts/simple/models.py
@@ -1,0 +1,9 @@
+from leader.models import Leader
+
+
+class Follow1(Leader):
+    pass
+
+
+class Follow2(Leader):
+    pass

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -62,13 +62,13 @@ class TestErrors:
 
             out = """
             main:15: error: Can't use a TypeGuard that uses a Concrete Annotation that uses type variables  [misc]
-            main:16: note: Revealed type is "type[Concrete?[T_Parent?]]"
+            main:16: note: Revealed type is "type[extended_mypy_django_plugin.annotations.Concrete[myapp.models.Parent]]"
             main:24: error: Can't use a TypeGuard that uses a Concrete Annotation that uses type variables  [misc]
-            main:25: note: Revealed type is "Concrete?[T_Parent?]"
+            main:25: note: Revealed type is "extended_mypy_django_plugin.annotations.Concrete[myapp.models.Parent]"
             main:40: error: Can't use a TypeGuard that uses a Concrete Annotation that uses type variables  [misc]
-            main:41: note: Revealed type is "type[Concrete?[T_Parent?]]"
+            main:41: note: Revealed type is "type[extended_mypy_django_plugin.annotations.Concrete[T_Parent`-1]]"
             main:44: error: Can't use a TypeGuard that uses a Concrete Annotation that uses type variables  [misc]
-            main:45: note: Revealed type is "Concrete?[T_Parent?]"
+            main:45: note: Revealed type is "extended_mypy_django_plugin.annotations.Concrete[T_Parent`-1]"
             """
 
             if importlib.metadata.version("mypy") == "1.4.0":


### PR DESCRIPTION
Prior to this you couldn't create a Concrete.type_var before the
class being used. Also there were broken cases due to how the type
checker was receiving Unbound Types.

After this change the type checker should not receive unbound types,
except for the new special `__ConcreteWithTypeVar__` unbound type, which
is necessary so that mypy doesn't compare our resolved unions to the
empty Concrete/DefaultQueryset annotations we create.

This change also expands on the tests a little bit
