### PR TITLE
Improve tests

### DIFF
--- a/scripts/test_helpers/extended_mypy_django_plugin_test_driver/output_builder.py
+++ b/scripts/test_helpers/extended_mypy_django_plugin_test_driver/output_builder.py
@@ -1,4 +1,5 @@
 import collections
+import dataclasses
 import enum
 import importlib.metadata
 import re
@@ -17,27 +18,51 @@ from typing_extensions import Self, assert_never
 regexes = {
     "potential_instruction": re.compile(r"^\s*#\s*\^"),
     "instruction": re.compile(
-        r"^(?P<prefix_whitespace>\s*)#\s*\^\s*(?P<instruction>REVEAL|ERROR|NOTE)(\((?P<options>[^\)]*)\))?(?P<tag>\[[^\]]*\])?\s*\^\s*(?P<rest>.*)"
+        r"^(?P<prefix_whitespace>\s*)#\s*\^\s*(?P<instruction>TAG|REVEAL|ERROR|NOTE)(\((?P<options>[^\)]*)\))?(\[(?P<tag>[^\]]*)\])?\s*\^\s*(?P<rest>.*)"
     ),
     "assignment": re.compile(r"^(?P<var_name>[a-zA-Z0-9_]+)\s*(:[^=]+)?(=|$)"),
 }
 
 
 class _Instruction(enum.Enum):
+    TAG = "TAG"
     REVEAL = "REVEAL"
     ERROR = "ERROR"
     NOTE = "NOTE"
 
 
 class _Build:
+    @dataclasses.dataclass
+    class _File:
+        tags: dict[str, FileOutputMatcher] = dataclasses.field(default_factory=dict)
+        matchers: list[FileOutputMatcher] = dataclasses.field(default_factory=list)
+
+        def clear(self) -> None:
+            self.tags.clear()
+            self.matchers.clear()
+
     def __init__(self, for_daemon: bool) -> None:
         self.for_daemon = for_daemon
-        self._by_file: dict[str, list[OutputMatcher]] = collections.defaultdict(list)
+        self._by_file: dict[str, _Build._File] = collections.defaultdict(lambda: _Build._File())
         self.daemon_should_restart: bool = False
 
     @property
     def result(self) -> Sequence[OutputMatcher]:
-        return list(chain.from_iterable(self._by_file.values()))
+        return list(chain.from_iterable([f.matchers for f in self._by_file.values()]))
+
+    def matcher_for_tag(self, path: str, tag: str) -> FileOutputMatcher:
+        if path not in self._by_file or tag not in self._by_file[path].tags:
+            raise AssertionError(f"No previously made matcher for {path} with tag {tag}")
+
+        return self._by_file[path].tags[tag]
+
+    def remove_tagged(self, path: str, tag: str, leave_tag: bool = False) -> None:
+        lnum = self.matcher_for_tag(path, tag).lnum
+        self._by_file[path].matchers = [
+            matcher for matcher in self._by_file[path].matchers if matcher.lnum != lnum
+        ]
+        if not leave_tag:
+            del self._by_file[path].tags[tag]
 
     def add(
         self,
@@ -47,13 +72,35 @@ class _Build:
         severity: str,
         message: str,
         regex: bool = False,
+        tag: str = "",
+        tag_only: bool = False,
+        override_tag: bool = False,
     ) -> None:
         fname = path.removesuffix(".py")
-        self._by_file[path].append(
-            FileOutputMatcher(
-                fname, lnum, severity, message, regex=regex, col=None if col is None else str(col)
-            )
+        matcher = FileOutputMatcher(
+            fname, lnum, severity, message, regex=regex, col=None if col is None else str(col)
         )
+
+        for_file = self._by_file[path]
+
+        existing_matcher: FileOutputMatcher | None = None
+        if tag and override_tag and tag in for_file.tags:
+            existing_matcher = for_file.tags[tag]
+
+        if not tag_only:
+            if tag and override_tag and tag in for_file.tags:
+                for_file.matchers = [
+                    matcher for matcher in for_file.matchers if matcher is not existing_matcher
+                ]
+
+            for_file.matchers.append(matcher)
+
+        if tag:
+            if not override_tag:
+                assert (
+                    tag not in for_file.tags
+                ), f"Already have a matched tagged as {tag} for {path}"
+            for_file.tags[tag] = matcher
 
     def clear_path(self, path: str) -> None:
         self._by_file[path].clear()
@@ -84,6 +131,12 @@ class OutputBuilder:
         else:
             return message
 
+    def _split_lnum_or_tag(self, lnum_or_tag: int | str) -> tuple[int, str]:
+        if isinstance(lnum_or_tag, int):
+            return lnum_or_tag, ""
+        else:
+            return -1, lnum_or_tag
+
     def clear(self) -> Self:
         if self.target_file:
             self._build.clear_path(self.target_file)
@@ -111,68 +164,113 @@ class OutputBuilder:
         for matcher in extract_output_matchers_from_out(
             out, {}, regex=regex, for_daemon=self._build.for_daemon
         ):
-            self._build._by_file[f"{matcher.fname}.py"].append(matcher)
+            assert isinstance(matcher, FileOutputMatcher)
+            self._build._by_file[f"{matcher.fname}.py"].matchers.append(matcher)
         return self
 
-    def add_revealed_type(self, lnum: int, revealed_type: str) -> Self:
+    def add_revealed_type(self, lnum_or_tag: int | str, revealed_type: str, tag: str = "") -> Self:
+        assert self.target_file is not None
+
         revealed_type = self._normalise_message(revealed_type)
 
-        assert self.target_file is not None
+        lnum, itag = self._split_lnum_or_tag(lnum_or_tag)
+
+        if itag:
+            if not tag:
+                tag = itag
+            lnum = self._build.matcher_for_tag(self.target_file, tag).lnum
+
         self._build.add(
-            self.target_file, lnum, None, "note", f'Revealed type is "{revealed_type}"'
+            self.target_file,
+            lnum,
+            None,
+            "note",
+            f'Revealed type is "{revealed_type}"',
+            tag=tag,
+            override_tag=True,
         )
         return self
 
-    def change_revealed_type(self, lnum: int, message: str) -> Self:
-        message = self._normalise_message(message)
-
+    def remove_errors(self, lnum_or_tag: int | str, leave_tag: bool = False) -> Self:
         assert self.target_file is not None
 
-        found: list[FileOutputMatcher] = []
-        for matcher in self._build._by_file[self.target_file]:
-            if (
-                matcher.lnum == lnum
-                and matcher.severity == "note"
-                and matcher.message.startswith("Revealed type is")
-            ):
-                found.append(matcher)
+        lnum, tag = self._split_lnum_or_tag(lnum_or_tag)
 
-        assert len(found) == 1
-        found[0].message = f'Revealed type is "{message}"'
-        return self
+        if tag:
+            self._build.remove_tagged(self.target_file, tag, leave_tag=leave_tag)
+            return self
 
-    def remove_errors(self, lnum: int) -> Self:
-        assert self.target_file is not None
-
-        self._build._by_file[self.target_file] = [
+        self._build._by_file[self.target_file].matchers = [
             matcher
-            for matcher in self._build._by_file[self.target_file]
+            for matcher in self._build._by_file[self.target_file].matchers
             if matcher.lnum != lnum and matcher.severity != "error"
         ]
 
         return self
 
-    def add_error(self, lnum: int, error_type: str, message: str) -> Self:
+    def add_error(
+        self, lnum_or_tag: int | str, error_type: str, message: str, tag: str = ""
+    ) -> Self:
+        assert self.target_file is not None
+
         message = self._normalise_message(message)
 
-        assert self.target_file is not None
-        self._build.add(self.target_file, lnum, None, "error", f"{message}  [{error_type}]")
+        lnum, itag = self._split_lnum_or_tag(lnum_or_tag)
+
+        if itag:
+            if not tag:
+                tag = itag
+            lnum = self._build.matcher_for_tag(self.target_file, tag).lnum
+
+        self._build.add(
+            self.target_file,
+            lnum,
+            None,
+            "error",
+            f"{message}  [{error_type}]",
+            tag=tag,
+            override_tag=True,
+        )
         return self
 
-    def add_note(self, lnum: int, message: str) -> Self:
+    def replace_errors(self, tag: str, *errors: tuple[str, str]) -> Self:
+        assert self.target_file is not None
+
+        lnum = self._build.matcher_for_tag(self.target_file, tag).lnum
+        self.remove_errors(tag, leave_tag=True)
+
+        for error_type, message in errors:
+            self.add_error(lnum, error_type, message)
+
+        return self
+
+    def add_note(self, lnum_or_tag: int | str, message: str, tag: str = "") -> Self:
+        assert self.target_file is not None
+
         message = self._normalise_message(message)
 
-        assert self.target_file is not None
-        self._build.add(self.target_file, lnum, None, "note", message)
+        lnum, itag = self._split_lnum_or_tag(lnum_or_tag)
+
+        if itag:
+            if not tag:
+                tag = itag
+            lnum = self._build.matcher_for_tag(self.target_file, tag).lnum
+
+        self._build.add(self.target_file, lnum, None, "note", message, tag=tag, override_tag=True)
         return self
 
-    def remove_from_revealed_type(self, lnum: int, remove: str) -> Self:
+    def remove_from_revealed_type(self, lnum_or_tag: int | str, remove: str) -> Self:
+        assert self.target_file is not None
+
         remove = self._normalise_message(remove)
 
-        assert self.target_file is not None
+        lnum, tag = self._split_lnum_or_tag(lnum_or_tag)
+
+        if tag:
+            lnum = self._build.matcher_for_tag(self.target_file, tag).lnum
 
         found: list[FileOutputMatcher] = []
-        for matcher in self._build._by_file[self.target_file]:
+        for matcher in self._build._by_file[self.target_file].matchers:
             if (
                 matcher.lnum == lnum
                 and matcher.severity == "note"
@@ -185,6 +283,8 @@ class OutputBuilder:
         return self
 
     def parse_content(self, path: str, content: str | None) -> str | None:
+        self._build.clear_path(path)
+
         if content is None:
             return content
 
@@ -211,8 +311,8 @@ class OutputBuilder:
                 line,
                 prefix_whitespace=gd["prefix_whitespace"],
                 instruction=_Instruction(gd["instruction"]),
-                options=gd.get("options", ""),
-                tag=gd.get("tag", ""),
+                options=gd.get("options", "") or "",
+                tag=gd.get("tag", "") or "",
                 rest=gd["rest"],
             )
 
@@ -239,12 +339,16 @@ class OutputBuilder:
             else:
                 result[i - 1] = f"{prefix_whitespace}reveal_type({previous_line.strip()})"
 
-            self.add_revealed_type(i, rest)
+            self.add_revealed_type(i, rest, tag=tag)
         elif instruction is _Instruction.ERROR:
             assert options, "Must use `# ^ ERROR(error-type) ^ error here`"
-            self.add_error(i, options, rest)
+            self.add_error(i, options, rest, tag=tag)
         elif instruction is _Instruction.NOTE:
-            self.add_note(i, rest)
+            self.add_note(i, rest, tag=tag)
+        elif instruction is _Instruction.TAG:
+            assert tag, "Must use a `# ^ TAG[tag-name] ^`"
+            assert self.target_file is not None
+            self._build.add(self.target_file, i, None, "error", "", tag=tag, tag_only=True)
         else:
             assert_never(instruction)
 

--- a/tests/test_concrete_annotations.py
+++ b/tests/test_concrete_annotations.py
@@ -14,30 +14,34 @@ class TestConcreteAnnotations:
                 from extended_mypy_django_plugin import Concrete
 
                 model: type[Leader] = Follow1
-                # ^ REVEAL model ^ type[leader.models.Leader]
+                # ^ REVEAL ^ type[leader.models.Leader]
 
                 model = Concrete.cast_as_concrete(model)
-                # ^ REVEAL model ^ Union[type[simple.models.Follow1], type[simple.models.Follow2]]
+                # ^ REVEAL ^ Union[type[simple.models.Follow1], type[simple.models.Follow2]]
 
                 model2: type[Leader] = Follow1
-                # ^ REVEAL model2 ^ type[leader.models.Leader]
+                # ^ REVEAL ^ type[leader.models.Leader]
 
                 model3 = Concrete.cast_as_concrete(model2)
-                # ^ REVEAL model3 ^ Union[type[simple.models.Follow1], type[simple.models.Follow2]]
-                # ^ REVEAL model2 ^ type[leader.models.Leader]
+                # ^ REVEAL ^ Union[type[simple.models.Follow1], type[simple.models.Follow2]]
+
+                model2
+                # ^ REVEAL ^ type[leader.models.Leader]
 
                 instance: Leader = Follow1.objects.create()
-                # ^ REVEAL instance ^ leader.models.Leader
+                # ^ REVEAL ^ leader.models.Leader
 
                 instance = Concrete.cast_as_concrete(instance)
-                # ^ REVEAL instance ^ Union[simple.models.Follow1, simple.models.Follow2]
+                # ^ REVEAL ^ Union[simple.models.Follow1, simple.models.Follow2]
 
                 instance2: Leader = Follow1.objects.create()
-                # ^ REVEAL instance2 ^ leader.models.Leader
+                # ^ REVEAL ^ leader.models.Leader
 
                 instance3 = Concrete.cast_as_concrete(instance2)
-                # ^ REVEAL instance3 ^ Union[simple.models.Follow1, simple.models.Follow2]
-                # ^ REVEAL instance2 ^ leader.models.Leader
+                # ^ REVEAL ^ Union[simple.models.Follow1, simple.models.Follow2]
+
+                instance2
+                # ^ REVEAL ^ leader.models.Leader
                 """,
             )
 
@@ -60,63 +64,65 @@ class TestConcreteAnnotations:
                     return True
 
                 models: Concrete[Parent]
-                # ^ REVEAL models ^ Union[myapp.models.Child1, myapp.models.Child2, myapp.models.Child3, myapp2.models.ChildOther]
+                # ^ REVEAL ^ Union[myapp.models.Child1, myapp.models.Child2, myapp.models.Child3, myapp2.models.ChildOther]
 
                 qs: DefaultQuerySet[Parent]
-                # ^ REVEAL qs ^ Union[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1], myapp.models.Child2QuerySet, django.db.models.query.QuerySet[myapp.models.Child3, myapp.models.Child3], django.db.models.query.QuerySet[myapp2.models.ChildOther, myapp2.models.ChildOther]]
+                # ^ REVEAL ^ Union[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1], myapp.models.Child2QuerySet, django.db.models.query.QuerySet[myapp.models.Child3, myapp.models.Child3], django.db.models.query.QuerySet[myapp2.models.ChildOther, myapp2.models.ChildOther]]
 
                 cls: type[Parent] = Child1
                 assert check_cls_with_type_guard(cls)
-                # ^ REVEAL cls ^ Union[type[myapp.models.Child1], type[myapp.models.Child2], type[myapp.models.Child3], type[myapp2.models.ChildOther]]
+                cls
+                # ^ REVEAL ^ Union[type[myapp.models.Child1], type[myapp.models.Child2], type[myapp.models.Child3], type[myapp2.models.ChildOther]]
 
                 instance: Parent = cast(Child1, None)
                 assert check_instance_with_type_guard(instance)
-                # ^ REVEAL instance ^ Union[myapp.models.Child1, myapp.models.Child2, myapp.models.Child3, myapp2.models.ChildOther]
+                instance
+                # ^ REVEAL ^ Union[myapp.models.Child1, myapp.models.Child2, myapp.models.Child3, myapp2.models.ChildOther]
 
                 children: Concrete[Parent]
-                # ^ REVEAL children ^ Union[myapp.models.Child1, myapp.models.Child2, myapp.models.Child3, myapp2.models.ChildOther]
+                # ^ REVEAL ^ Union[myapp.models.Child1, myapp.models.Child2, myapp.models.Child3, myapp2.models.ChildOther]
 
                 children_qs: DefaultQuerySet[Parent]
-                # ^ REVEAL children_qs ^ Union[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1], myapp.models.Child2QuerySet, django.db.models.query.QuerySet[myapp.models.Child3, myapp.models.Child3], django.db.models.query.QuerySet[myapp2.models.ChildOther, myapp2.models.ChildOther]]
+                # ^ REVEAL ^ Union[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1], myapp.models.Child2QuerySet, django.db.models.query.QuerySet[myapp.models.Child3, myapp.models.Child3], django.db.models.query.QuerySet[myapp2.models.ChildOther, myapp2.models.ChildOther]]
 
                 child: Concrete[Child1]
-                # ^ REVEAL child ^ myapp.models.Child1
+                # ^ REVEAL ^ myapp.models.Child1
 
                 child1_qs: DefaultQuerySet[Child1]
-                # ^ REVEAL child1_qs ^ django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1]
+                # ^ REVEAL ^ django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1]
 
                 child2_qs: DefaultQuerySet[Child2]
-                # ^ REVEAL child2_qs ^ myapp.models.Child2QuerySet
+                # ^ REVEAL ^ myapp.models.Child2QuerySet
 
                 t1_children: type[Concrete[Parent]]
-                # ^ REVEAL t1_children ^ Union[type[myapp.models.Child1], type[myapp.models.Child2], type[myapp.models.Child3], type[myapp2.models.ChildOther]]
+                # ^ REVEAL ^ Union[type[myapp.models.Child1], type[myapp.models.Child2], type[myapp.models.Child3], type[myapp2.models.ChildOther]]
 
                 t1_children_qs: type[DefaultQuerySet[Parent]]
-                # ^ REVEAL t1_children_qs ^ Union[type[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1]], type[myapp.models.Child2QuerySet], type[django.db.models.query.QuerySet[myapp.models.Child3, myapp.models.Child3]], type[django.db.models.query.QuerySet[myapp2.models.ChildOther, myapp2.models.ChildOther]]]
+                # ^ REVEAL ^ Union[type[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1]], type[myapp.models.Child2QuerySet], type[django.db.models.query.QuerySet[myapp.models.Child3, myapp.models.Child3]], type[django.db.models.query.QuerySet[myapp2.models.ChildOther, myapp2.models.ChildOther]]]
 
                 t1_child: type[Concrete[Child1]]
-                # ^ REVEAL t1_child ^ type[myapp.models.Child1]
+                # ^ REVEAL ^ type[myapp.models.Child1]
 
                 t1_child1_qs: type[DefaultQuerySet[Child1]]
-                # ^ REVEAL t1_child1_qs ^ type[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1]]
+                # ^ REVEAL ^ type[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1]]
 
                 t1_child2_qs: type[DefaultQuerySet[Child2]]
-                # ^ REVEAL t1_child2_qs ^ type[myapp.models.Child2QuerySet]
+                # ^ REVEAL ^ type[myapp.models.Child2QuerySet]
 
                 t2_children: Concrete[type[Parent]]
-                # ^ REVEAL t2_children ^ Union[type[myapp.models.Child1], type[myapp.models.Child2], type[myapp.models.Child3], type[myapp2.models.ChildOther]]
+                # ^ REVEAL ^ Union[type[myapp.models.Child1], type[myapp.models.Child2], type[myapp.models.Child3], type[myapp2.models.ChildOther]]
 
                 t2_children_qs: DefaultQuerySet[type[Parent]]
-                # ^ REVEAL t2_children_qs ^ Union[type[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1]], type[myapp.models.Child2QuerySet], type[django.db.models.query.QuerySet[myapp.models.Child3, myapp.models.Child3]], type[django.db.models.query.QuerySet[myapp2.models.ChildOther, myapp2.models.ChildOther]]]
+                # ^ REVEAL ^ Union[type[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1]], type[myapp.models.Child2QuerySet], type[django.db.models.query.QuerySet[myapp.models.Child3, myapp.models.Child3]], type[django.db.models.query.QuerySet[myapp2.models.ChildOther, myapp2.models.ChildOther]]]
 
                 t2_child: Concrete[type[Child1]]
-                # ^ REVEAL t2_child ^ type[myapp.models.Child1]
+                # ^ REVEAL ^ type[myapp.models.Child1]
 
                 t2_child1_qs: DefaultQuerySet[type[Child1]]
-                # ^ REVEAL t2_child1_qs ^ type[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1]]
+                # ^ REVEAL ^ type[django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1]]
 
                 t2_child2_qs: DefaultQuerySet[type[Child2]]
-                # ^ REVEAL t2_child2_qs ^ type[myapp.models.Child2QuerySet]
+                # ^ REVEAL ^ type[myapp.models.Child2QuerySet]
                 """,
             )
 
@@ -152,7 +158,7 @@ class TestConcreteAnnotations:
                     @classmethod
                     def new(cls) -> Concrete[Self]:
                         cls = Concrete.cast_as_concrete(cls)
-                        # ^ REVEAL cls ^ Union[type[example.models.Follower1], type[example.models.Follower2]]
+                        # ^ REVEAL ^ Union[type[example.models.Follower1], type[example.models.Follower2]]
                         return cls.objects.create()
 
                     class Meta:
@@ -178,17 +184,17 @@ class TestConcreteAnnotations:
                 from extended_mypy_django_plugin import Concrete
 
                 instance1 = make_instance(Follower1)
-                # ^ REVEAL instance1 ^ example.models.Follower1
+                # ^ REVEAL ^ example.models.Follower1
 
                 instance2 = make_instance(Follower2)
-                # ^ REVEAL instance2 ^ example.models.Follower2
+                # ^ REVEAL ^ example.models.Follower2
                 """,
                 # TODO: Make this possible
                 # would require generating overload variants on make_instance
                 # model: type[Concrete[Leader]] = Follower1
-                # # ^ REVEAL model ^ Union[type[example.models.Follower1], type[example.models.Follower2]]
+                # # ^ REVEAL ^ Union[type[example.models.Follower1], type[example.models.Follower2]]
                 # instance3 = make_instance(model)
-                # # ^ REVEAL instance3 ^ Union[example.models.Follower1, example.models.Follower2]
+                # # ^ REVEAL ^ Union[example.models.Follower1, example.models.Follower2]
                 # """,
             )
 
@@ -226,12 +232,12 @@ class TestConcreteAnnotations:
                     @classmethod
                     def new(cls) -> Concrete[Self]:
                         cls = Concrete.cast_as_concrete(cls)
-                        # ^ REVEAL cls ^ Union[type[example.models.Follower1], type[example.models.Follower2]]
+                        # ^ REVEAL ^ Union[type[example.models.Follower1], type[example.models.Follower2]]
                         return cls.objects.create()
 
                     def qs(self) -> DefaultQuerySet[Self]:
                         self = Concrete.cast_as_concrete(self)
-                        # ^ REVEAL self ^ Union[example.models.Follower1, example.models.Follower2]
+                        # ^ REVEAL ^ Union[example.models.Follower1, example.models.Follower2]
                         return self.__class__.objects.filter(pk=self.pk)
 
                     class Meta:
@@ -258,26 +264,27 @@ class TestConcreteAnnotations:
                 from extended_mypy_django_plugin import Concrete
 
                 model: type[Leader] = Follower1
-                # ^ REVEAL model ^ type[example.models.Leader]
+                # ^ REVEAL ^ type[example.models.Leader]
 
                 leader = model.new()
-                # ^ REVEAL leader ^ Union[example.models.Follower1, example.models.Follower2]
+                # ^ REVEAL ^ Union[example.models.Follower1, example.models.Follower2]
 
                 qs = leader.qs()
-                # ^ REVEAL qs ^ Union[example.models.Follower1QuerySet, django.db.models.query.QuerySet[example.models.Follower2, example.models.Follower2]]
+                # ^ REVEAL ^ Union[example.models.Follower1QuerySet, django.db.models.query.QuerySet[example.models.Follower2, example.models.Follower2]]
 
                 follower1 = Follower1.new()
-                # ^ REVEAL follower1 ^ example.models.Follower1
+                # ^ REVEAL ^ example.models.Follower1
 
                 qs3 = Follower2.new().qs()
-                # ^ REVEAL qs3 ^ django.db.models.query.QuerySet[example.models.Follower2, example.models.Follower2]
+                # ^ REVEAL ^ django.db.models.query.QuerySet[example.models.Follower2, example.models.Follower2]
 
                 other: Leader = Follower1.new()
-                # ^ REVEAL other ^ example.models.Leader
+                # ^ REVEAL ^ example.models.Leader
 
                 narrowed = Concrete.cast_as_concrete(other)
-                # ^ REVEAL narrowed ^ Union[example.models.Follower1, example.models.Follower2]
-                # ^ REVEAL other ^ example.models.Leader
+                # ^ REVEAL ^ Union[example.models.Follower1, example.models.Follower2]
+                other
+                # ^ REVEAL ^ example.models.Leader
                 """,
             )
 
@@ -347,22 +354,21 @@ class TestConcreteAnnotations:
                 from extended_mypy_django_plugin import Concrete
 
                 follower1 = Follower1.objects.create()
-                # ^ REVEAL follower1 ^ example.models.Follower1
+                # ^ REVEAL ^ example.models.Follower1
 
                 func = functions[0]
-                # ^ REVEAL func ^ example.models.MakeQueryset
+                # ^ REVEAL ^ example.models.MakeQueryset
 
                 func2 = functions2[0]
-                # ^ REVEAL func ^ example.models.MakeQueryset
                 
                 qs1 = func(follower1)
-                # ^ REVEAL qs1 ^ example.models.Follower1QuerySet
+                # ^ REVEAL ^ example.models.Follower1QuerySet
 
                 qs2 = func2(follower1)
-                # ^ REVEAL qs2 ^ example.models.Follower1QuerySet
+                # ^ REVEAL ^ example.models.Follower1QuerySet
 
                 qs5 = make_queryset(follower1)
-                # ^ REVEAL qs5 ^ example.models.Follower1QuerySet
+                # ^ REVEAL ^ example.models.Follower1QuerySet
                 """,
             )
 

--- a/tests/test_concrete_annotations.py
+++ b/tests/test_concrete_annotations.py
@@ -320,7 +320,9 @@ class TestConcreteAnnotations:
                     class Meta:
                         abstract = True
 
+                # TODO: the error is fixed in future commit
                 T_Leader = Concrete.type_var("T_Leader", Leader)
+                # ^ ERROR(misc) ^ No concrete children found for example.models.Leader
 
                 class Follower1QuerySet(models.QuerySet["Follower1"]):
                     ...
@@ -370,11 +372,6 @@ class TestConcreteAnnotations:
                 qs5 = make_queryset(follower1)
                 # ^ REVEAL ^ example.models.Follower1QuerySet
                 """,
-            )
-
-            # TODO: Fixed in future commit
-            expected.on("example/models.py").add_error(
-                13, "misc", "No concrete children found for example.models.Leader"
             )
 
     def test_sees_apps_removed_when_they_still_exist_but_no_longer_installed(

--- a/tests/test_concrete_annotations.py
+++ b/tests/test_concrete_annotations.py
@@ -5,9 +5,8 @@ class TestConcreteAnnotations:
     def test_cast_as_concrete(self, scenario: Scenario) -> None:
         @scenario.run_and_check_mypy_after(installed_apps=["leader", "simple"])
         def _(expected: OutputBuilder) -> None:
-            scenario.make_file_with_reveals(
+            scenario.file(
                 expected,
-                10,
                 "main.py",
                 """
                 from simple.models import Follow1, Follow2
@@ -45,9 +44,8 @@ class TestConcreteAnnotations:
     def test_simple_annotation(self, scenario: Scenario) -> None:
         @scenario.run_and_check_mypy_after
         def _(expected: OutputBuilder) -> None:
-            scenario.make_file_with_reveals(
+            scenario.file(
                 expected,
-                19,
                 "main.py",
                 """
                 from extended_mypy_django_plugin import Concrete, DefaultQuerySet
@@ -125,9 +123,10 @@ class TestConcreteAnnotations:
     def test_can_use_type_var_before_class_is_defined(self, scenario: Scenario) -> None:
         @scenario.run_and_check_mypy_after(installed_apps=["example"])
         def _(expected: OutputBuilder) -> None:
-            scenario.make_file("example/__init__.py", "")
+            scenario.file(expected, "example/__init__.py", "")
 
-            scenario.make_file(
+            scenario.file(
+                expected,
                 "example/apps.py",
                 """
                 from django.apps import AppConfig
@@ -137,7 +136,8 @@ class TestConcreteAnnotations:
                 """,
             )
 
-            scenario.make_file(
+            scenario.file(
+                expected,
                 "example/models.py",
                 """
                 from __future__ import annotations
@@ -170,9 +170,8 @@ class TestConcreteAnnotations:
                 """,
             )
 
-            scenario.make_file_with_reveals(
+            scenario.file(
                 expected,
-                2,
                 "main.py",
                 """
                 from example.models import Leader, Follower1, Follower2, make_instance
@@ -198,9 +197,10 @@ class TestConcreteAnnotations:
     ) -> None:
         @scenario.run_and_check_mypy_after(installed_apps=["example"])
         def _(expected: OutputBuilder) -> None:
-            scenario.make_file("example/__init__.py", "")
+            scenario.file(expected, "example/__init__.py", "")
 
-            scenario.make_file(
+            scenario.file(
+                expected,
                 "example/apps.py",
                 """
                 from django.apps import AppConfig
@@ -210,7 +210,8 @@ class TestConcreteAnnotations:
                 """,
             )
 
-            scenario.make_file(
+            scenario.file(
+                expected,
                 "example/models.py",
                 """
                 from __future__ import annotations
@@ -249,9 +250,8 @@ class TestConcreteAnnotations:
                 """,
             )
 
-            scenario.make_file_with_reveals(
+            scenario.file(
                 expected,
-                8,
                 "main.py",
                 """
                 from example.models import Leader, Follower1, Follower2
@@ -284,9 +284,10 @@ class TestConcreteAnnotations:
     def test_resolving_concrete_type_vars(self, scenario: Scenario) -> None:
         @scenario.run_and_check_mypy_after(installed_apps=["example"])
         def _(expected: OutputBuilder) -> None:
-            scenario.make_file("example/__init__.py", "")
+            scenario.file(expected, "example/__init__.py", "")
 
-            scenario.make_file(
+            scenario.file(
+                expected,
                 "example/apps.py",
                 """
                 from django.apps import AppConfig
@@ -296,7 +297,8 @@ class TestConcreteAnnotations:
                 """,
             )
 
-            scenario.make_file(
+            scenario.file(
+                expected,
                 "example/models.py",
                 """
                 from __future__ import annotations
@@ -337,9 +339,8 @@ class TestConcreteAnnotations:
                 """,
             )
 
-            scenario.make_file_with_reveals(
+            scenario.file(
                 expected,
-                6,
                 "main.py",
                 """
                 from example.models import Leader, Follower1, Follower2, functions, functions2, make_queryset
@@ -375,7 +376,8 @@ class TestConcreteAnnotations:
     ) -> None:
         @scenario.run_and_check_mypy_after
         def _(expected: OutputBuilder) -> None:
-            scenario.make_file(
+            scenario.file(
+                expected,
                 "main.py",
                 """
                 from extended_mypy_django_plugin import Concrete, DefaultQuerySet
@@ -425,7 +427,8 @@ class TestConcreteAnnotations:
             installed_apps=["myapp"], copied_apps=["myapp", "myapp2"]
         )
         def _(expected: OutputBuilder) -> None:
-            scenario.make_file(
+            scenario.file(
+                expected,
                 "main.py",
                 """
                 from extended_mypy_django_plugin import Concrete, DefaultQuerySet
@@ -463,7 +466,8 @@ class TestConcreteAnnotations:
     def test_sees_models_when_they_are_added_and_installed(self, scenario: Scenario) -> None:
         @scenario.run_and_check_mypy_after(installed_apps=["myapp"])
         def _(expected: OutputBuilder) -> None:
-            scenario.make_file(
+            scenario.file(
+                expected,
                 "main.py",
                 """
                 from extended_mypy_django_plugin import Concrete, DefaultQuerySet
@@ -512,7 +516,8 @@ class TestConcreteAnnotations:
     def test_sees_new_models(self, scenario: Scenario) -> None:
         @scenario.run_and_check_mypy_after
         def _(expected: OutputBuilder) -> None:
-            scenario.make_file(
+            scenario.file(
+                expected,
                 "main.py",
                 """
                 from extended_mypy_django_plugin import Concrete, DefaultQuerySet
@@ -532,6 +537,7 @@ class TestConcreteAnnotations:
         @scenario.run_and_check_mypy_after
         def _(expected: OutputBuilder) -> None:
             scenario.append_to_file(
+                expected,
                 "myapp2/models.py",
                 """
                 class Another(Parent):
@@ -562,7 +568,8 @@ class TestConcreteAnnotations:
     def test_sees_changes_in_custom_querysets_within_app(self, scenario: Scenario) -> None:
         @scenario.run_and_check_mypy_after(installed_apps=["leader", "follower1"])
         def _(expected: OutputBuilder) -> None:
-            scenario.make_file(
+            scenario.file(
+                expected,
                 "main.py",
                 """
                 from extended_mypy_django_plugin import Concrete, DefaultQuerySet
@@ -593,7 +600,8 @@ class TestConcreteAnnotations:
 
         @scenario.run_and_check_mypy_after
         def _(expected: OutputBuilder) -> None:
-            scenario.update_file(
+            scenario.file(
+                expected,
                 "follower1/models/__init__.py",
                 """
                 from .follower1 import Follower1
@@ -603,7 +611,8 @@ class TestConcreteAnnotations:
                 """,
             )
 
-            scenario.update_file(
+            scenario.file(
+                expected,
                 "follower1/models/follower2.py",
                 """
                 from django.db import models
@@ -656,7 +665,8 @@ class TestConcreteAnnotations:
 
         @scenario.run_and_check_mypy_after
         def _(expected: OutputBuilder) -> None:
-            scenario.update_file(
+            scenario.file(
+                expected,
                 "follower1/models/follower2.py",
                 """
                 from django.db import models
@@ -692,7 +702,8 @@ class TestConcreteAnnotations:
     def test_sees_changes_in_custom_querysets_in_new_apps(self, scenario: Scenario) -> None:
         @scenario.run_and_check_mypy_after(installed_apps=["leader", "follower1"])
         def _(expected: OutputBuilder) -> None:
-            scenario.make_file(
+            scenario.file(
+                expected,
                 "main.py",
                 """
                 from extended_mypy_django_plugin import Concrete, DefaultQuerySet
@@ -723,9 +734,10 @@ class TestConcreteAnnotations:
 
         @scenario.run_and_check_mypy_after(installed_apps=["leader", "follower1", "follower2"])
         def _(expected: OutputBuilder) -> None:
-            scenario.update_file("follower2/__init__.py", "")
+            scenario.file(expected, "follower2/__init__.py", "")
 
-            scenario.update_file(
+            scenario.file(
+                expected,
                 "follower2/apps.py",
                 """
                 from django.apps import AppConfig
@@ -735,7 +747,8 @@ class TestConcreteAnnotations:
                 """,
             )
 
-            scenario.update_file(
+            scenario.file(
+                expected,
                 "follower2/models.py",
                 """
                 from django.db import models
@@ -780,7 +793,8 @@ class TestConcreteAnnotations:
 
         @scenario.run_and_check_mypy_after
         def _(expected: OutputBuilder) -> None:
-            scenario.update_file(
+            scenario.file(
+                expected,
                 "follower2/models.py",
                 """
                 from django.db import models

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -9,7 +9,8 @@ class TestErrors:
     ) -> None:
         @scenario.run_and_check_mypy_after
         def _(expected: OutputBuilder) -> None:
-            scenario.make_file(
+            scenario.file(
+                expected,
                 "main.py",
                 """
                 from typing import TypeGuard, TypeVar, cast, TypeVar

--- a/tests/test_works.py
+++ b/tests/test_works.py
@@ -16,70 +16,72 @@ def test_works(scenario: Scenario) -> None:
      main:59: note: Revealed type is "Union[myapp.models.Child2QuerySet, django.db.models.query.QuerySet[myapp.models.Child1, myapp.models.Child1]]"
      """
 
-    main = """
-    from extended_mypy_django_plugin import Concrete, DefaultQuerySet
-
-    from myapp.models import Parent, Child1, Child2
-
-    T_Child = Concrete.type_var("T_Child", Parent)
-
-
-    def make_child(child: type[T_Child]) -> T_Child:
-        return child.objects.create()
-
-
-    def make_any_queryset(child: type[Concrete[Parent]]) -> DefaultQuerySet[Parent]:
-        return child.objects.all()
-
-
-    def make_child1_queryset() -> DefaultQuerySet[Child1]:
-        return Child1.objects.all()
-
-
-    def make_child2_queryset() -> DefaultQuerySet[Child2]:
-        return Child2.objects.all()
-
-
-    def make_multiple_queryset(child: type[Child1 | Child2]) -> DefaultQuerySet[Child2 | Child1]:
-        return child.objects.all()
-
-
-    def make_child_typevar_queryset(child: type[T_Child]) -> DefaultQuerySet[T_Child]:
-        return child.objects.all()
-
-
-    def ones(model: type[Concrete[Parent]]) -> list[str]:
-        reveal_type(model.objects)
-        return list(model.objects.values_list("one", flat=True))
-
-
-    made = make_child(Child1)
-    reveal_type(made)
-
-    any_qs = make_any_queryset(Child1)
-    reveal_type(any_qs)
-
-    qs1 = make_child1_queryset()
-    reveal_type(qs1)
-
-    qs2 = make_child2_queryset()
-    reveal_type(qs2)
-    reveal_type(qs2.all())
-    reveal_type(Child2.objects)
-    reveal_type(Child2.objects.all())
-
-    tvqs1 = make_child_typevar_queryset(Child1)
-    reveal_type(tvqs1)
-
-    tvqs2 = make_child_typevar_queryset(Child2)
-    reveal_type(tvqs2)
-
-    tvqsmult = make_multiple_queryset(Child1)
-    reveal_type(tvqsmult)
-    """
-
     @scenario.run_and_check_mypy_after
     def _(expected: OutputBuilder) -> None:
-        scenario.file(expected, "main.py", main)
+        scenario.file(
+            expected,
+            "main.py",
+            """
+            from extended_mypy_django_plugin import Concrete, DefaultQuerySet
+
+            from myapp.models import Parent, Child1, Child2
+
+            T_Child = Concrete.type_var("T_Child", Parent)
+
+
+            def make_child(child: type[T_Child]) -> T_Child:
+                return child.objects.create()
+
+
+            def make_any_queryset(child: type[Concrete[Parent]]) -> DefaultQuerySet[Parent]:
+                return child.objects.all()
+
+
+            def make_child1_queryset() -> DefaultQuerySet[Child1]:
+                return Child1.objects.all()
+
+
+            def make_child2_queryset() -> DefaultQuerySet[Child2]:
+                return Child2.objects.all()
+
+
+            def make_multiple_queryset(child: type[Child1 | Child2]) -> DefaultQuerySet[Child2 | Child1]:
+                return child.objects.all()
+
+
+            def make_child_typevar_queryset(child: type[T_Child]) -> DefaultQuerySet[T_Child]:
+                return child.objects.all()
+
+
+            def ones(model: type[Concrete[Parent]]) -> list[str]:
+                reveal_type(model.objects)
+                return list(model.objects.values_list("one", flat=True))
+
+
+            made = make_child(Child1)
+            reveal_type(made)
+
+            any_qs = make_any_queryset(Child1)
+            reveal_type(any_qs)
+
+            qs1 = make_child1_queryset()
+            reveal_type(qs1)
+
+            qs2 = make_child2_queryset()
+            reveal_type(qs2)
+            reveal_type(qs2.all())
+            reveal_type(Child2.objects)
+            reveal_type(Child2.objects.all())
+
+            tvqs1 = make_child_typevar_queryset(Child1)
+            reveal_type(tvqs1)
+
+            tvqs2 = make_child_typevar_queryset(Child2)
+            reveal_type(tvqs2)
+
+            tvqsmult = make_multiple_queryset(Child1)
+            reveal_type(tvqsmult)
+            """,
+        )
 
         expected.from_out(out)

--- a/tests/test_works.py
+++ b/tests/test_works.py
@@ -80,6 +80,6 @@ def test_works(scenario: Scenario) -> None:
 
     @scenario.run_and_check_mypy_after
     def _(expected: OutputBuilder) -> None:
-        scenario.make_file("main.py", main)
+        scenario.file(expected, "main.py", main)
 
         expected.from_out(out)


### PR DESCRIPTION
This makes it much easier to use the inline output expectations and allows to change existing expectations by name rather than by line number.

These changes make it far less likely to be testing the wrong variables and removes the need to track line numbers in the errors