### PR TITLE
Make sure that the determine_version check failing doesn't crash dmypy

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -17,6 +17,7 @@ Changelog
     * Implemented Concrete.cast_as_concrete
     * Concrete.type_var can now take a forward reference to the model being represented
     * Implemented more scenarios where Concrete.type_var may be used
+    * Handle failure of the script for determining the version without crashing dmypy
 
 .. _release-0.5.3:
 

--- a/extended_mypy_django_plugin/plugin/_reports.py
+++ b/extended_mypy_django_plugin/plugin/_reports.py
@@ -376,7 +376,32 @@ class Reports:
                 if err.returncode == 2:
                     return 1 if previous_version is None else previous_version
                 else:
-                    raise
+                    message = [
+                        "",
+                        "Failed to determine information about the django setup",
+                        "",
+                        f"  > {' '.join(cmd)}",
+                        "  |",
+                    ]
+                    if err.stdout:
+                        for line in err.stdout.splitlines():
+                            if isinstance(line, bytes):
+                                line = line.decode()
+                            message.append(f"  | {line}")
+                        if err.stderr:
+                            message.append("  |")
+                    if err.stderr:
+                        for line in err.stderr.splitlines():
+                            if isinstance(line, bytes):
+                                line = line.decode()
+                            message.append(f"  | {line}")
+                    message.append("  |")
+
+                    if previous_version:
+                        print("\n".join(message), file=sys.stderr)  # noqa: T201
+                        return previous_version
+                    else:
+                        raise RuntimeError("\n".join(message)) from None
 
             installed_apps_hash = str(zlib.adler32(pathlib.Path(result_file.name).read_bytes()))
             known_models_hash = str(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,3 +58,4 @@ select = [
 [tool.ruff.lint.per-file-ignores]
 "example/djangoexample/views.py" = ["F821"]
 "extended_mypy_django_plugin/plugin/_debug.py" = ["T201"]
+"scripts/test_helpers/extended_mypy_django_plugin_test_driver/assertions.py" = ["T201"]

--- a/scripts/test_helpers/extended_mypy_django_plugin_test_driver/assertions.py
+++ b/scripts/test_helpers/extended_mypy_django_plugin_test_driver/assertions.py
@@ -1,0 +1,29 @@
+import fnmatch
+
+
+def assert_glob_lines(got: str, expect: str) -> None:
+    message = [line.strip() for line in got.strip().replace("\r\n", "\n").split("\n")]
+    want = [line.strip() for line in expect.strip().split("\n")]
+
+    print("GOT >>" + "=" * 74)
+    print()
+    print("\n".join(message))
+    print()
+    print("WANT >>" + "-" * 73)
+    print()
+    print("\n".join(want))
+
+    count = 1
+    while want:
+        line = want[0]
+        if not message:
+            assert False, f"Ran out of lines, stopped at [{count}] '{want[0]}'"
+
+        if message[0] == line or fnmatch.fnmatch(message[0], line):
+            count += 1
+            want.pop(0)
+
+        message.pop(0)
+
+    if want:
+        assert False, f"Didn't match all the lines, stopped at [{count}] '{want[0]}'"


### PR DESCRIPTION
After this change if the script to determine if we should restart dmypy fails then we return the previous version and continue using the existing understanding of the django project.

We print out the error that happened with the command we ran to get that error