### PR TITLE
Make it so dmypy restarts if there are different settings

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -3,6 +3,11 @@
 Changelog
 ---------
 
+.. _release-0.5.5:
+
+0.5.5 - TBD
+    * Make it possible to restart dmypy if settings names/types change
+
 .. _release-0.5.4:
 
 0.5.4 - 4 June 2024

--- a/docs/api/tracking-changes.rst
+++ b/docs/api/tracking-changes.rst
@@ -55,6 +55,10 @@ This file will be executed with the following arguments:
     This is a path to a file. The script must write the name of each installed model to it with
     each name on their own line
 
+--extra-info-file
+    This is a path to a file. The script must write any other information that is deemed worthy of
+    restarting dmypy over.
+
 The contents of these files are hashed and used to determine a version. So if they are different since
 the last time dmypy was run, then dmypy will restart itself before analysis.
 

--- a/extended_mypy_django_plugin/scripts/__init__.py
+++ b/extended_mypy_django_plugin/scripts/__init__.py
@@ -1,3 +1,9 @@
 from .find_models import find_known_models, record_known_models
+from .find_settings import find_known_settings, record_known_settings
 
-__all__ = ["record_known_models", "find_known_models"]
+__all__ = [
+    "record_known_models",
+    "find_known_models",
+    "find_known_settings",
+    "record_known_settings",
+]

--- a/extended_mypy_django_plugin/scripts/find_settings.py
+++ b/extended_mypy_django_plugin/scripts/find_settings.py
@@ -1,0 +1,22 @@
+import pathlib
+from collections.abc import Iterator
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from django.conf import LazySettings
+
+
+def record_known_settings(output_location: pathlib.Path, settings: "LazySettings") -> None:
+    found: set[str] = set()
+    for line in find_known_settings(settings):
+        found.add(line)
+
+    output_location.write_text("\n".join(sorted(found)))
+
+
+def find_known_settings(settings: "LazySettings") -> Iterator[str]:
+    for name in dir(settings):
+        if name.startswith("_"):
+            continue
+
+        yield f"{name} :: {type(getattr(settings, name))}"

--- a/scripts/test_helpers/extended_mypy_django_plugin_test_driver/extension_hook.py
+++ b/scripts/test_helpers/extended_mypy_django_plugin_test_driver/extension_hook.py
@@ -2,6 +2,7 @@ import ast
 import os
 import pathlib
 import runpy
+import textwrap
 from collections.abc import Mapping, MutableSequence
 from typing import TYPE_CHECKING
 
@@ -62,7 +63,7 @@ class Hooks(ScenarioHooks):
             if current_settings.exists():
                 return options
 
-        if not current_settings.exists():
+        if not current_settings.exists() or custom_settings is not None:
             with open(current_settings, "w") as fle:
                 fle.write("")
 
@@ -121,7 +122,7 @@ class Hooks(ScenarioHooks):
             fle.write(ast.unparse(ast.fix_missing_locations(settings)))
             if isinstance(custom_settings, str):
                 fle.write("\n")
-                fle.write(custom_settings)
+                fle.write(textwrap.dedent(custom_settings))
 
         if current_settings.read_text() != original_settings_text:
             new_settings = current_settings.read_text()


### PR DESCRIPTION
Prior to this if there are django settings with different names or types than before then dmypy wouldn't restart.

This can result in dmypy not understanding the shape of the django settings

This change hooks into the existing version change mechanism to make it so that dmypy will restart when that happens