### PR TITLE
Starting to add django analysis code

### DIFF
--- a/example/djangoexample/settings.py
+++ b/example/djangoexample/settings.py
@@ -13,6 +13,8 @@ https://docs.djangoproject.com/en/4.2/ref/settings/
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 
+UNIQUE_SETTING_TO_EXTENDED_MYPY_PLUGIN_DJANGOEXAMPLE = "unique"
+
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 

--- a/extended_mypy_django_plugin/django_analysis/__init__.py
+++ b/extended_mypy_django_plugin/django_analysis/__init__.py
@@ -1,0 +1,3 @@
+from . import protocols
+
+__all__ = ["protocols"]

--- a/extended_mypy_django_plugin/django_analysis/__init__.py
+++ b/extended_mypy_django_plugin/django_analysis/__init__.py
@@ -1,3 +1,4 @@
 from . import protocols
+from .hasher import adler32_hash
 
-__all__ = ["protocols"]
+__all__ = ["protocols", "adler32_hash"]

--- a/extended_mypy_django_plugin/django_analysis/__init__.py
+++ b/extended_mypy_django_plugin/django_analysis/__init__.py
@@ -1,4 +1,12 @@
 from . import protocols
 from .hasher import adler32_hash
+from .project import AnalyzedProject, LoadedProject, Project, replaced_env_vars_and_sys_path
 
-__all__ = ["protocols", "adler32_hash"]
+__all__ = [
+    "protocols",
+    "adler32_hash",
+    "Project",
+    "LoadedProject",
+    "AnalyzedProject",
+    "replaced_env_vars_and_sys_path",
+]

--- a/extended_mypy_django_plugin/django_analysis/hasher.py
+++ b/extended_mypy_django_plugin/django_analysis/hasher.py
@@ -1,0 +1,12 @@
+import zlib
+from typing import TYPE_CHECKING
+
+from . import protocols
+
+
+def adler32_hash(*parts: bytes) -> str:
+    return str(zlib.adler32(b"\n".join(parts)))
+
+
+if TYPE_CHECKING:
+    _a32h: protocols.Hasher = adler32_hash

--- a/extended_mypy_django_plugin/django_analysis/project.py
+++ b/extended_mypy_django_plugin/django_analysis/project.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import contextlib
+import dataclasses
+import os
+import pathlib
+import sys
+import types
+from collections.abc import Iterator, Mapping, Sequence
+from typing import TYPE_CHECKING, cast
+
+from django.apps.registry import Apps
+from django.conf import LazySettings
+
+from . import protocols
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class replaced_env_vars_and_sys_path:
+    """
+    Helper to modify sys.path and os.environ such that those changes are reversed
+    upon exiting the contextmanager
+    """
+
+    additional_sys_path: Sequence[str]
+    env_vars: Mapping[str, str]
+
+    undo_env: dict[str, str | None] = dataclasses.field(init=False, default_factory=dict)
+    remove_path: list[str] = dataclasses.field(init=False, default_factory=list)
+
+    def __enter__(self) -> None:
+        # Determine what to undo later
+        for k, v in self.env_vars.items():
+            if k not in os.environ:
+                self.undo_env[k] = None
+            else:
+                self.undo_env[k] = os.environ[k]
+
+        for path in self.additional_sys_path:
+            if path not in sys.path:
+                self.remove_path.append(path)
+
+        # Make the change itself
+        for path in self.additional_sys_path:
+            if path not in sys.path:
+                sys.path.append(path)
+
+        for k, v in self.env_vars.items():
+            os.environ[k] = v
+
+    def __exit__(self, exc_type: type[Exception], tb: types.TracebackType, exc: Exception) -> None:
+        for path in self.remove_path:
+            if path in sys.path:
+                sys.path.remove(path)
+
+        for k, v in self.undo_env.items():
+            if v is None:
+                if k in os.environ:
+                    del os.environ[k]
+            else:
+                os.environ[k] = v
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class Project:
+    root_dir: pathlib.Path
+    additional_sys_path: Sequence[str]
+    env_vars: Mapping[str, str]
+    hasher: protocols.Hasher
+
+    known_models_analyzer: protocols.KnownModelsAnalayzer
+    settings_types_analyzer: protocols.SettingsTypesAnalyzer
+
+    @contextlib.contextmanager
+    def setup_sys_path_and_env_vars(self) -> Iterator[None]:
+        with replaced_env_vars_and_sys_path(
+            additional_sys_path=self.additional_sys_path, env_vars=self.env_vars
+        ):
+            yield
+
+    @contextlib.contextmanager
+    def instantiate_django(self) -> Iterator[protocols.LoadedProject]:
+        with self.setup_sys_path_and_env_vars():
+            from django.apps import apps
+            from django.conf import settings
+
+            if not settings.configured:
+                settings._setup()  # type: ignore[misc]
+            apps.populate(settings.INSTALLED_APPS)
+
+            assert apps.apps_ready, "Apps are not ready"
+            assert settings.configured, "Settings are not configured"
+
+            yield LoadedProject(
+                root_dir=self.root_dir,
+                hasher=self.hasher,
+                env_vars=self.env_vars,
+                settings=settings,
+                apps=apps,
+                known_models_analyzer=self.known_models_analyzer,
+                settings_types_analyzer=self.settings_types_analyzer,
+            )
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class LoadedProject:
+    root_dir: pathlib.Path
+    env_vars: Mapping[str, str]
+    settings: LazySettings
+    apps: Apps
+    hasher: protocols.Hasher
+
+    known_models_analyzer: protocols.KnownModelsAnalayzer
+    settings_types_analyzer: protocols.SettingsTypesAnalyzer
+
+    def analyze_project(self) -> protocols.AnalyzedProject:
+        return AnalyzedProject(
+            hasher=self.hasher,
+            loaded_project=self,
+            installed_apps=self.settings.INSTALLED_APPS,
+            settings_types=self.settings_types_analyzer(self),
+            known_model_modules=self.known_models_analyzer(self),
+        )
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class AnalyzedProject:
+    hasher: protocols.Hasher
+    loaded_project: LoadedProject
+
+    installed_apps: list[str]
+    settings_types: Mapping[str, str]
+    known_model_modules: Mapping[protocols.ImportPath, protocols.Module]
+
+
+if TYPE_CHECKING:
+    _P: protocols.Project = cast(Project, None)
+    _LP: protocols.LoadedProject = cast(LoadedProject, None)
+    _AP: protocols.AnalyzedProject = cast(AnalyzedProject, None)

--- a/extended_mypy_django_plugin/django_analysis/protocols.py
+++ b/extended_mypy_django_plugin/django_analysis/protocols.py
@@ -1,0 +1,423 @@
+from __future__ import annotations
+
+import contextlib
+import pathlib
+from collections.abc import Hashable, Iterator, Mapping, Sequence, Set
+from typing import TYPE_CHECKING, NewType, Protocol
+
+from django.apps.registry import Apps
+from django.conf import LazySettings
+
+ImportPath = NewType("ImportPath", str)
+
+
+class Hasher(Protocol):
+    def __call__(self, *parts: bytes) -> str:
+        """
+        Given some strings, create a single hash of all that data
+        """
+
+
+class SettingsTypesAnalyzer(Protocol):
+    """
+    Used determine the Django settings and their types in a Django project
+    """
+
+    def __call__(self, loaded_project: LoadedProject, /) -> Mapping[str, str]: ...
+
+
+class KnownModelsAnalayzer(Protocol):
+    """
+    Used Find and analyze the known models in a Django project
+    """
+
+    def __call__(self, loaded_project: LoadedProject, /) -> Mapping[ImportPath, Module]: ...
+
+
+class Project(Protocol):
+    """
+    Represents a Django project to be analyzed
+    """
+
+    @property
+    def root_dir(self) -> pathlib.Path:
+        """
+        Where the django project lives
+        """
+
+    @property
+    def additional_sys_path(self) -> Sequence[str]:
+        """
+        Any additional paths that need to be added to sys.path
+        """
+
+    @property
+    def env_vars(self) -> Mapping[str, str]:
+        """
+        Any additional environment variables needed to setup Django
+        """
+
+    @property
+    def hasher(self) -> Hasher:
+        """
+        An object for creating hashes from strings
+        """
+
+    @contextlib.contextmanager
+    def setup_sys_path_and_env_vars(self) -> Iterator[None]:
+        """
+        Do necessary work to setup and cleanup changes to sys.path and os.environ to prepare
+        for a django instantiation.
+        """
+
+    @contextlib.contextmanager
+    def instantiate_django(self) -> Iterator[LoadedProject]:
+        """
+        Do necessary work to load Django into memory
+
+        It is expected that an implementation will use self.setup_sys_path_and_env_vars to
+        setup and cleanup required changes to sys.path and os.environ
+        """
+
+
+class LoadedProject(Protocol):
+    """
+    Represents a Django project that has been setup and loaded into memory
+    """
+
+    @property
+    def root_dir(self) -> pathlib.Path:
+        """
+        Where the django project lives
+        """
+
+    @property
+    def hasher(self) -> Hasher:
+        """
+        An object for creating hashes from strings
+        """
+
+    @property
+    def env_vars(self) -> Mapping[str, str]:
+        """
+        Any additional environment variables that were used during Django setup
+        """
+
+    @property
+    def settings(self) -> LazySettings:
+        """
+        The instantiated Django settings object
+        """
+
+    @property
+    def apps(self) -> Apps:
+        """
+        The instantiated Django apps registry
+        """
+
+    def analyze_project(self) -> AnalyzedProject:
+        """
+        Perform analysis on the loaded django project
+        """
+
+
+class AnalyzedProject(Protocol):
+    @property
+    def loaded_project(self) -> LoadedProject:
+        """
+        The loaded django project that was analyzed
+        """
+
+    @property
+    def hasher(self) -> Hasher:
+        """
+        An object for creating hashes from strings
+        """
+
+    @property
+    def known_model_modules(self) -> Mapping[ImportPath, Module]:
+        """
+        The known modules that contain installed Django Models
+        """
+
+    @property
+    def installed_apps(self) -> list[str]:
+        """
+        The value of the settings.INSTALLED_APPS setting.
+        """
+
+    @property
+    def settings_types(self) -> Mapping[str, str]:
+        """
+        All the django settings and a string representation of their type
+        """
+
+
+class Module(Protocol, Hashable):
+    """
+    The models contained within a specific module
+    """
+
+    @property
+    def hasher(self) -> Hasher:
+        """
+        An object for creating hashes from strings
+        """
+
+    @property
+    def virtual_dependency_import_path(self) -> ImportPath:
+        """
+        The full import path for the relevant virtual dependency
+        """
+
+    @property
+    def installed(self) -> bool:
+        """
+        Whether this module is part of the installed django apps
+        """
+
+    @property
+    def import_path(self) -> ImportPath:
+        """
+        The full import path for this module
+        """
+
+    @property
+    def defined_models_by_name(self) -> Mapping[ImportPath, Model]:
+        """
+        A map of the installed models defined in this module
+        """
+
+    @property
+    def related_modules(self) -> Set[Module]:
+        """
+        All the modules that have models that are related to the models in this module
+        """
+
+    @property
+    def models_hash(self) -> str:
+        """
+        A hash of all the models in this file and all the related modules
+        """
+
+
+class Model(Protocol, Hashable):
+    """
+    Represents the information contained by a Django model
+    """
+
+    @property
+    def model_name(self) -> str:
+        """
+        The name of the class that this model represents
+        """
+
+    @property
+    def import_path(self) -> ImportPath:
+        """
+        The full import path to this model
+        """
+
+    @property
+    def is_abstract(self) -> bool:
+        """
+        Whether this model is abstract
+        """
+
+    @property
+    def ancestors(self) -> Set[ImportPath]:
+        """
+        The import paths to all the models that have a parent relationship to this model
+        """
+
+    @property
+    def descendents(self) -> Set[ImportPath]:
+        """
+        The import paths to all the models that have a child relationship to this model
+        """
+
+    @property
+    def default_custom_queryset(self) -> ImportPath | None:
+        """
+        The import path to the default custom queryset for this model if one is defined
+        """
+
+    @property
+    def defined_fields(self) -> Set[str]:
+        """
+        The names of the fields defined on this model
+        """
+
+    @property
+    def all_fields(self) -> Mapping[str, Field]:
+        """
+        The final collection of fields this model knows about
+        """
+
+    @property
+    def virtual_dependency(self) -> VirtualDependency:
+        """
+        The information relevant to this model to creating a virtual dependency
+        """
+
+    @property
+    def model_hash(self) -> str:
+        """
+        A hash of the fields on this model and all the related models
+        """
+
+
+class Field(Protocol):
+    """
+    Represents a single field on a model
+    """
+
+    @property
+    def model(self) -> Model:
+        """
+        The model this field is defined on
+        """
+
+    @property
+    def field_type(self) -> ImportPath:
+        """
+        The import path to the type of object used to represent this type
+        """
+
+    @property
+    def related_models(self) -> Set[ImportPath]:
+        """
+        The import paths to all the models related to this model by this field
+        """
+
+
+class VirtualDependencyNamer(Protocol):
+    @property
+    def hasher(self) -> Hasher:
+        """
+        An object for creating hashes from strings
+        """
+
+    @property
+    def namespace(self) -> str:
+        """
+        The import namespace for virtual dependencies
+        """
+
+    def __call__(self, module: ImportPath, /) -> ImportPath:
+        """
+        Return a deterministically determined name representing this module import path
+        """
+
+
+class VirtualDependencyCreator(Protocol):
+    """
+    Represents the work to create virtual dependencies for a django project
+    """
+
+    @property
+    def analyzed_project(self) -> AnalyzedProject:
+        """
+        The analyzed project dependencies are being made for
+        """
+
+    @property
+    def virtual_dependency_root(self) -> pathlib.Path:
+        """
+        The path to put the virtual dependency folder into
+        """
+
+    def generate_virtual_dependencies(self, tmp_path: pathlib.Path) -> None:
+        """
+        Generate all the virtual dependencies onto disk for a project into the provided path
+        """
+
+    def replace_reports(self, tmp_path: pathlib.Path) -> None:
+        """
+        Replace the virtual dependencies with those found in the tmp_path, making sure to delete
+        left over reports that represent deleted modules
+        """
+
+
+class VirtualDependencySummary(Protocol):
+    """
+    Represents the different hashes that make up a full hash for a virtual dependency
+
+    This is used to determine if the dependency has changed or not
+    """
+
+    @property
+    def virtual_dependency_name(self) -> ImportPath:
+        """
+        The import path the virtual dependency lives at
+        """
+
+    @property
+    def module_import_path(self) -> ImportPath:
+        """
+        The import path to the real module this virtual dependency represents
+        """
+
+    @property
+    def installed_apps_hash(self) -> str | None:
+        """
+        The hash of the installed apps if this module is part of the installed apps
+        """
+
+    @property
+    def deps_hash(self) -> str | None:
+        """
+        The hash of the related modules/models if this module is part of the installed apps
+        """
+
+
+class VirtualDependency(Protocol):
+    """
+    Represents the information held by a virtual dependency for a module
+    """
+
+    @property
+    def hasher(self) -> Hasher:
+        """
+        An object for creating hashes from strings
+        """
+
+    @property
+    def module(self) -> Module:
+        """
+        The module represented by this virtual dependency
+        """
+
+    @property
+    def interface_differentiator(self) -> str:
+        """
+        A string used to change the public interface of this virtual dependency
+        """
+
+    @property
+    def summary(self) -> VirtualDependencySummary:
+        """
+        The parts that make up a final hash for this virtual dependency
+        """
+
+    @property
+    def concrete_annotations(self) -> Mapping[Model, Sequence[Model]]:
+        """
+        The models known by this module and their concrete children
+        """
+
+
+if TYPE_CHECKING:
+    P_Model = Model
+    P_Field = Field
+    P_Module = Module
+    P_Hasher = Hasher
+    P_Project = Project
+    P_LoadedProject = LoadedProject
+    P_AnalyzedProject = AnalyzedProject
+    P_VirtualDependency = VirtualDependency
+    P_KnownModelsAnalayzer = KnownModelsAnalayzer
+    P_SettingsTypesAnalyzer = SettingsTypesAnalyzer
+    P_VirtualDependencyNamer = VirtualDependencyNamer
+    P_VirtualDependencySummary = VirtualDependencySummary
+    P_VirtualDependencyCreator = VirtualDependencyCreator

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,6 +2,7 @@
 testpaths = tests
 console_output_style = classic
 addopts =
+    -p pytester
     --tb=short
     --mypy-ini-file=scripts/mypy.ini
     --mypy-extension-hook=extended_mypy_django_plugin_test_driver.extension_hook.django_plugin_hook

--- a/tests/django_analysis/test_hasher.py
+++ b/tests/django_analysis/test_hasher.py
@@ -1,0 +1,28 @@
+import os
+import pathlib
+
+from extended_mypy_django_plugin.django_analysis import hasher
+
+tests_dir = pathlib.Path(__file__).parent.parent
+
+
+class TestAdler32Hash:
+    def test_it_creates_a_consistent_hash(self) -> None:
+        found: dict[str, str] = {}
+        for root, _, files in os.walk(tests_dir):
+            for name in files:
+                made: set[str] = set()
+                content = (pathlib.Path(root) / name).read_bytes()
+
+                for i in range(10):
+                    made.add(hasher.adler32_hash(*content.splitlines()))
+
+                # naive check to show the hash is consistent
+                assert len(made) == 1
+                hsh = next(iter(made))
+                assert len(hsh) < 32
+                found[name] = hsh
+
+        # naive check to show the hash is different for different content
+        assert len(set(found)) > 5
+        assert len(set(found)) == len(set(found.values()))

--- a/tests/django_analysis/test_project.py
+++ b/tests/django_analysis/test_project.py
@@ -1,0 +1,166 @@
+import inspect
+import os
+import pathlib
+import sys
+import textwrap
+from typing import TYPE_CHECKING
+
+import pytest
+
+from extended_mypy_django_plugin.django_analysis import project, protocols
+
+project_root = pathlib.Path(__file__).parent.parent.parent
+
+
+def _hasher(*parts: bytes) -> str:
+    return f"||hashed>>{' '.join(p.decode() for p in parts)}||"
+
+
+if TYPE_CHECKING:
+    _h: protocols.Hasher = _hasher
+
+
+class TestReplacedEnvVarsAndSysPath:
+    def test_it_can_handle_env_vars(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("one", "one_val")
+        monkeypatch.setenv("two", "two_val")
+
+        monkeypatch.setenv("three", "tobedeleted")
+        monkeypatch.delenv("three")
+
+        all_env = dict(os.environ)
+
+        assert "three" not in all_env
+        assert all_env["one"] == "one_val"
+        assert all_env["two"] == "two_val"
+
+        with project.replaced_env_vars_and_sys_path(
+            additional_sys_path=[], env_vars={"one": "blah", "three": "twenty"}
+        ):
+            changed = dict(os.environ)
+
+        assert dict(os.environ) == all_env
+        assert all_env != changed
+        assert changed == {**all_env, "one": "blah", "three": "twenty"}
+
+    def test_it_can_handle_changes_to_sys_path(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(sys, "path", ["one", "two", "three"])
+
+        all_path = list(sys.path)
+        assert all_path == ["one", "two", "three"]
+
+        with project.replaced_env_vars_and_sys_path(
+            additional_sys_path=["two", "four"], env_vars={}
+        ):
+            changed = list(sys.path)
+
+        assert list(sys.path) == ["one", "two", "three"]
+        assert changed == ["one", "two", "three", "four"]
+
+
+class TestProject:
+    def test_getting_an_analyzed_project(
+        self, pytester: pytest.Pytester, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """
+        Using pytester to make it easier to run a test in a subprocess so we don't poison the import space
+        """
+
+        def test_getting_project() -> None:
+            import dataclasses
+            import os
+            import pathlib
+            from collections.abc import Mapping, Set
+            from typing import TYPE_CHECKING
+
+            from django.apps.registry import Apps
+            from django.conf import LazySettings
+
+            from extended_mypy_django_plugin.django_analysis import Project
+
+            @dataclasses.dataclass(frozen=True, kw_only=True)
+            class FakeModule:
+                hasher: protocols.Hasher = _hasher
+                virtual_dependency_import_path: protocols.ImportPath = dataclasses.field(
+                    default_factory=lambda: protocols.ImportPath("virtual")
+                )
+                installed: bool = True
+                import_path: protocols.ImportPath = dataclasses.field(
+                    default_factory=lambda: protocols.ImportPath("somewhere")
+                )
+                defined_models_by_name: Mapping[protocols.ImportPath, protocols.Model] = (
+                    dataclasses.field(default_factory=dict)
+                )
+                related_modules: Set[protocols.Module] = dataclasses.field(default_factory=set)
+                models_hash: str = ""
+
+            fake_module = FakeModule()
+
+            def settings_type_analyzer(
+                loaded_project: protocols.LoadedProject, /
+            ) -> Mapping[str, str]:
+                assert (
+                    loaded_project.settings.UNIQUE_SETTING_TO_EXTENDED_MYPY_PLUGIN_DJANGOEXAMPLE  # type: ignore[misc]
+                    == "unique"
+                )
+                return {"not": "accurate"}
+
+            def known_models_analyzer(
+                loaded_project: protocols.LoadedProject, /
+            ) -> Mapping[protocols.ImportPath, protocols.Module]:
+                return {fake_module.import_path: fake_module}
+
+            if TYPE_CHECKING:
+                _sta: protocols.SettingsTypesAnalyzer = settings_type_analyzer
+                _kma: protocols.KnownModelsAnalayzer = known_models_analyzer
+
+            root_dir = pathlib.Path(os.environ["PROJECT_ROOT"]) / "example"
+            project = Project(
+                root_dir=root_dir,
+                hasher=_hasher,
+                additional_sys_path=[str(root_dir)],
+                settings_types_analyzer=settings_type_analyzer,
+                known_models_analyzer=known_models_analyzer,
+                env_vars={"DJANGO_SETTINGS_MODULE": "djangoexample.settings"},
+            )
+
+            with project.instantiate_django() as loaded_project:
+                analyzed_project = loaded_project.analyze_project()
+
+            assert loaded_project.root_dir == root_dir
+            assert loaded_project.hasher is _hasher
+            assert loaded_project.env_vars == project.env_vars
+            assert isinstance(loaded_project.settings, LazySettings)
+            assert (
+                loaded_project.settings.UNIQUE_SETTING_TO_EXTENDED_MYPY_PLUGIN_DJANGOEXAMPLE  # type: ignore[misc]
+                == "unique"
+            )
+            assert isinstance(loaded_project.apps, Apps)
+
+            assert analyzed_project.loaded_project is loaded_project
+            assert analyzed_project.hasher is _hasher
+            assert analyzed_project.installed_apps == [
+                "django.contrib.admin",
+                "django.contrib.auth",
+                "django.contrib.contenttypes",
+                "django.contrib.sessions",
+                "django.contrib.messages",
+                "django.contrib.staticfiles",
+                "djangoexample.exampleapp",
+                "djangoexample.exampleapp2",
+            ]
+            assert analyzed_project.settings_types == {"not": "accurate"}
+            assert analyzed_project.known_model_modules == {fake_module.import_path: fake_module}
+
+        test_content = (
+            "from extended_mypy_django_plugin.django_analysis import protocols"
+            + "\n\n"
+            + inspect.getsource(_hasher)
+            + "\n\n"
+            + textwrap.dedent(inspect.getsource(test_getting_project))
+        )
+        pytester.makepyfile(test_content)
+
+        monkeypatch.setenv("PROJECT_ROOT", str(project_root))
+        result = pytester.runpytest_subprocess("-vvv")
+        result.assert_outcomes(passed=1)


### PR DESCRIPTION
The final piece of the puzzle for this plugin appears to be resolving a bug where mypy still doesn't see when certain models have changed.

The way around this is to resolve concrete annotations by referring to type aliases in the virtual dependencies, so that the resolution of the annotations is directly tied to the content of those files.

To facilitate I'm creating code that is responsible for analyzing a django project to create all the necessary information upfront before continuing with mypy specific parts of the plugin.

This PR is the first step towards that.

I've included protocols for the objects I believe will be necessary. It is very likely this will change a bit as I start to implement the objects. This PR only implements the initial Project objects that are responsible for loading the django project before analysis begins.