### PR TITLE
Make everything generic in terms of the project

### DIFF
--- a/extended_mypy_django_plugin/django_analysis/__init__.py
+++ b/extended_mypy_django_plugin/django_analysis/__init__.py
@@ -4,7 +4,7 @@ from .fields import Field
 from .hasher import adler32_hash
 from .models import Model
 from .modules import Module
-from .project import DiscoveredProject, LoadedProject, Project, replaced_env_vars_and_sys_path
+from .project import Discovered, Loaded, Project, replaced_env_vars_and_sys_path
 
 __all__ = [
     "protocols",
@@ -15,7 +15,7 @@ __all__ = [
     "Model",
     "Module",
     "Project",
-    "LoadedProject",
-    "DiscoveredProject",
+    "Loaded",
+    "Discovered",
     "replaced_env_vars_and_sys_path",
 ]

--- a/extended_mypy_django_plugin/django_analysis/discovery/container.py
+++ b/extended_mypy_django_plugin/django_analysis/discovery/container.py
@@ -1,14 +1,14 @@
 import dataclasses
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Generic, cast
 
 from .. import protocols
 
 
 @dataclasses.dataclass
-class Discovery:
-    discover_settings_types: protocols.SettingsTypesDiscovery
-    discover_installed_models: protocols.InstalledModelsDiscovery
+class Discovery(Generic[protocols.T_Project]):
+    discover_settings_types: protocols.SettingsTypesDiscovery[protocols.T_Project]
+    discover_installed_models: protocols.InstalledModelsDiscovery[protocols.T_Project]
 
 
 if TYPE_CHECKING:
-    _A: protocols.Discovery = cast(Discovery, None)
+    _A: protocols.P_Discovery = cast(Discovery[protocols.P_Project], None)

--- a/extended_mypy_django_plugin/django_analysis/discovery/known_models.py
+++ b/extended_mypy_django_plugin/django_analysis/discovery/known_models.py
@@ -3,7 +3,7 @@ import inspect
 import types
 from collections import defaultdict
 from collections.abc import Iterator, Sequence
-from typing import TYPE_CHECKING, Any, Protocol, cast
+from typing import TYPE_CHECKING, Any, Generic, Protocol, cast
 
 from django.db import models
 
@@ -22,10 +22,12 @@ class ModuleCreator(Protocol):
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
-class DefaultInstalledModulesDiscovery:
+class DefaultInstalledModulesDiscovery(Generic[protocols.T_Project]):
     module_creator: ModuleCreator
 
-    def __call__(self, loaded_project: protocols.LoadedProject, /) -> protocols.ModelModulesMap:
+    def __call__(
+        self, loaded_project: protocols.Loaded[protocols.T_Project], /
+    ) -> protocols.ModelModulesMap:
         found: dict[protocols.ImportPath, list[type[models.Model]]] = defaultdict(list)
         for concrete_model_cls in loaded_project.apps.get_models():
             found[ImportPath.cls_module(concrete_model_cls)].append(concrete_model_cls)
@@ -77,4 +79,6 @@ class DefaultInstalledModulesDiscovery:
 
 
 if TYPE_CHECKING:
-    _KMA: protocols.InstalledModelsDiscovery = cast(DefaultInstalledModulesDiscovery, None)
+    _KMA: protocols.P_InstalledModelsDiscovery = cast(
+        DefaultInstalledModulesDiscovery[protocols.P_Project], None
+    )

--- a/extended_mypy_django_plugin/django_analysis/discovery/settings_types.py
+++ b/extended_mypy_django_plugin/django_analysis/discovery/settings_types.py
@@ -1,17 +1,19 @@
 import dataclasses
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Generic, cast
 
 from .. import protocols
 
 
 @dataclasses.dataclass
-class NaiveSettingsTypesDiscovery:
+class NaiveSettingsTypesDiscovery(Generic[protocols.T_Project]):
     """
     The default implementation is a little naive and is only able to rely on inspecting
     the values on the settings object.
     """
 
-    def __call__(self, loaded_project: protocols.LoadedProject, /) -> protocols.SettingsTypesMap:
+    def __call__(
+        self, loaded_project: protocols.Loaded[protocols.T_Project], /
+    ) -> protocols.SettingsTypesMap:
         result: dict[str, str] = {}
         settings = loaded_project.settings
 
@@ -24,10 +26,12 @@ class NaiveSettingsTypesDiscovery:
         return result
 
     def type_from_setting(
-        self, loaded_project: protocols.LoadedProject, name: str, value: object
+        self, loaded_project: protocols.Loaded[protocols.T_Project], name: str, value: object
     ) -> str:
         return str(type(value))
 
 
 if TYPE_CHECKING:
-    _STA: protocols.SettingsTypesDiscovery = cast(NaiveSettingsTypesDiscovery, None)
+    _STA: protocols.P_SettingsTypesDiscovery = cast(
+        NaiveSettingsTypesDiscovery[protocols.P_Project], None
+    )

--- a/tests/django_analysis/conftest.py
+++ b/tests/django_analysis/conftest.py
@@ -17,7 +17,7 @@ root_dir = pathlib.Path(__file__).parent.parent.parent
 
 
 @pytest.fixture(scope="session")
-def loaded_django_example() -> protocols.LoadedProject:
+def loaded_django_example() -> protocols.Loaded[Project]:
     field_creator = Field.create
     model_creator = functools.partial(Model.create, field_creator=field_creator)
     module_creator = functools.partial(Module.create, model_creator=model_creator)

--- a/tests/django_analysis/test_analyze_known_models.py
+++ b/tests/django_analysis/test_analyze_known_models.py
@@ -4,12 +4,12 @@ from collections.abc import Sequence
 
 from django.db import models
 
-from extended_mypy_django_plugin.django_analysis import ImportPath, discovery, protocols
+from extended_mypy_django_plugin.django_analysis import ImportPath, Project, discovery, protocols
 
 
 class TestKnownModelsAnalyzer:
     def test_it_finds_modules_that_have_models(
-        self, loaded_django_example: protocols.LoadedProject
+        self, loaded_django_example: protocols.Loaded[Project]
     ) -> None:
         @dataclasses.dataclass
         class Module:
@@ -36,9 +36,9 @@ class TestKnownModelsAnalyzer:
                 default_factory=dict
             )
 
-        known_modules = discovery.DefaultInstalledModulesDiscovery(module_creator=Module.create)(
-            loaded_django_example
-        )
+        known_modules = discovery.DefaultInstalledModulesDiscovery[Project](
+            module_creator=Module.create
+        )(loaded_django_example)
 
         import django.contrib.admin.models
         import django.contrib.auth.models

--- a/tests/django_analysis/test_analyze_settings_types.py
+++ b/tests/django_analysis/test_analyze_settings_types.py
@@ -1,11 +1,11 @@
-from extended_mypy_django_plugin.django_analysis import discovery, protocols
+from extended_mypy_django_plugin.django_analysis import Project, discovery, protocols
 
 
 class TestSettingsTypesAnalyzer:
     def test_it_looks_at_values_to_determine_types(
-        self, loaded_django_example: protocols.LoadedProject
+        self, loaded_django_example: protocols.Loaded[Project]
     ) -> None:
-        settings_types = discovery.NaiveSettingsTypesDiscovery()(loaded_django_example)
+        settings_types = discovery.NaiveSettingsTypesDiscovery[Project]()(loaded_django_example)
         assert settings_types == {
             "ABSOLUTE_URL_OVERRIDES": "<class 'dict'>",
             "ADMINS": "<class 'list'>",

--- a/tests/django_analysis/test_models.py
+++ b/tests/django_analysis/test_models.py
@@ -6,11 +6,18 @@ import functools
 import pytest
 from typing_extensions import Self
 
-from extended_mypy_django_plugin.django_analysis import Field, ImportPath, Model, Module, protocols
+from extended_mypy_django_plugin.django_analysis import (
+    Field,
+    ImportPath,
+    Model,
+    Module,
+    Project,
+    protocols,
+)
 
 
 @pytest.fixture(autouse=True)
-def _ensure_django_loaded(loaded_django_example: protocols.LoadedProject) -> None:
+def _ensure_django_loaded(loaded_django_example: protocols.Loaded[Project]) -> None:
     """
     Make sure the loaded_django_example fixture is active so that we can import our djangoexample models inside tests
     """

--- a/tests/django_analysis/test_project.py
+++ b/tests/django_analysis/test_project.py
@@ -98,7 +98,7 @@ class TestProject:
 
             class Discovery:
                 def discover_settings_types(
-                    self, loaded_project: protocols.LoadedProject, /
+                    self, loaded_project: protocols.Loaded[Project], /
                 ) -> protocols.SettingsTypesMap:
                     assert (
                         loaded_project.settings.UNIQUE_SETTING_TO_EXTENDED_MYPY_PLUGIN_DJANGOEXAMPLE  # type: ignore[misc]
@@ -107,12 +107,12 @@ class TestProject:
                     return {"not": "accurate"}
 
                 def discover_installed_models(
-                    self, loaded_project: protocols.LoadedProject, /
+                    self, loaded_project: protocols.Loaded[Project], /
                 ) -> protocols.ModelModulesMap:
                     return {fake_module.import_path: fake_module}
 
             if TYPE_CHECKING:
-                _sta: protocols.Discovery = cast(Discovery, None)
+                _sta: protocols.Discovery[Project] = cast(Discovery, None)
 
             root_dir = pathlib.Path(os.environ["PROJECT_ROOT"]) / "example"
             project = Project(


### PR DESCRIPTION
This is so that special things can be put on the project that may be used in customized versions of everything after that point

For example knowing that the project uses django-configurations