### PR TITLE
Introduce a report for the mypy plugin to use

### DIFF
--- a/extended_mypy_django_plugin/django_analysis/protocols.py
+++ b/extended_mypy_django_plugin/django_analysis/protocols.py
@@ -569,6 +569,26 @@ class ReportCombinerMaker(Protocol[T_Report]):
     def __call__(self, reports: Sequence[T_Report]) -> ReportCombiner[T_Report]: ...
 
 
+class ReportFactory(Protocol[T_VirtualDependency, T_Report]):
+    """
+    Holds everything necessary for creating reports
+    """
+
+    @property
+    def report_installer(self) -> ReportInstaller: ...
+
+    @property
+    def report_maker(self) -> ReportMaker[T_Report]: ...
+
+    @property
+    def virtual_dependency_scribe_maker(
+        self,
+    ) -> VirtualDependencyScribeMaker[T_VirtualDependency, T_Report]: ...
+
+    @property
+    def report_combiner_maker(self) -> ReportCombinerMaker[T_Report]: ...
+
+
 if TYPE_CHECKING:
     P_Model = Model
     P_Field = Field
@@ -591,6 +611,7 @@ if TYPE_CHECKING:
     P_ReportCombinerMaker = ReportCombinerMaker[P_Report]
     P_VirtualDependencyScribe = VirtualDependencyScribe[P_VirtualDependency, P_Report]
     P_VirtualDependencyScribeMaker = VirtualDependencyScribeMaker[P_VirtualDependency, P_Report]
+    P_ReportFactory = ReportFactory[P_VirtualDependency, P_Report]
 
     P_VirtualDependencyMaker = VirtualDependencyMaker[P_Project, P_VirtualDependency]
     P_VirtualDependencyNamer = VirtualDependencyNamer

--- a/extended_mypy_django_plugin/django_analysis/protocols.py
+++ b/extended_mypy_django_plugin/django_analysis/protocols.py
@@ -523,6 +523,27 @@ class VirtualDependencyScribeMaker(Protocol[T_VirtualDependency, T_CO_Report]):
     ) -> VirtualDependencyScribe[T_VirtualDependency, T_CO_Report]: ...
 
 
+class ReportInstaller(Protocol):
+    """
+    Used to write reports to the file system
+    """
+
+    def write_report(
+        self, *, scratch_root: pathlib.Path, virtual_import_path: ImportPath, content: str
+    ) -> None:
+        """
+        Write a single report to the scratch path
+        """
+
+    def install_reports(self, scratch_path: pathlib.Path, destination: pathlib.Path) -> None:
+        """
+        Copy reports from scratch_path into the destination when the reports on the destination
+        are different to the reports in the scratch path.
+
+        Also, delete redundant reports from destination
+        """
+
+
 class ReportCombiner(Protocol[T_CO_Report]):
     """
     Used to combine many reports into one
@@ -565,6 +586,7 @@ if TYPE_CHECKING:
     P_VirtualDependency = VirtualDependency
 
     P_ReportMaker = ReportMaker[P_Report]
+    P_ReportInstaller = ReportInstaller
     P_ReportCombiner = ReportCombiner[P_Report]
     P_ReportCombinerMaker = ReportCombinerMaker[P_Report]
     P_VirtualDependencyScribe = VirtualDependencyScribe[P_VirtualDependency, P_Report]

--- a/extended_mypy_django_plugin/django_analysis/protocols.py
+++ b/extended_mypy_django_plugin/django_analysis/protocols.py
@@ -14,9 +14,9 @@ if TYPE_CHECKING:
     from django.contrib.contenttypes.fields import GenericForeignKey
     from django.db.models.fields.related import ForeignObjectRel
 
-T_Project = TypeVar("T_Project", bound="Project")
+T_Project = TypeVar("T_Project", bound="P_Project")
 T_CO_VirtualDependency = TypeVar(
-    "T_CO_VirtualDependency", bound="VirtualDependency", covariant=True
+    "T_CO_VirtualDependency", bound="P_VirtualDependency", covariant=True
 )
 
 ImportPath = NewType("ImportPath", str)

--- a/extended_mypy_django_plugin/django_analysis/protocols.py
+++ b/extended_mypy_django_plugin/django_analysis/protocols.py
@@ -320,41 +320,27 @@ class VirtualDependencyMaker(Protocol[T_Project, T_CO_VirtualDependency]):
     ) -> T_CO_VirtualDependency: ...
 
 
-class VirtualDependencyGenerator(Protocol[T_Project, T_CO_VirtualDependency]):
+class VirtualDependencyGenerator(Protocol[T_Project, T_CO_VirtualDependency, T_CO_Report]):
     """
     Object that generates the objects representing the virtual dependencies
     """
 
-    @property
-    def discovered_project(self) -> Discovered[T_Project]:
-        """
-        The project with discovered information
-        """
-
-    @property
-    def virtual_dependency_maker(
-        self,
-    ) -> VirtualDependencyMaker[T_Project, T_CO_VirtualDependency]:
-        """
-        Used to generate a virtual dependency for a module
-        """
-
-    def generate(self) -> GeneratedVirtualDependencies[T_CO_VirtualDependency]:
+    def __call__(
+        self, *, discovered_project: Discovered[T_Project]
+    ) -> GeneratedVirtualDependencies[T_CO_VirtualDependency, T_CO_Report]:
         """
         Generate the virtual dependencies for this project
         """
 
 
-class GeneratedVirtualDependencies(Protocol[T_CO_VirtualDependency]):
+class GeneratedVirtualDependencies(Protocol[T_CO_VirtualDependency, T_CO_Report]):
     @property
     def virtual_dependencies(self) -> VirtualDependencyMap[T_CO_VirtualDependency]:
         """
         The virtual dependency items
         """
 
-    def install(
-        self, *, scratch_root: pathlib.Path, destination: pathlib.Path, hasher: Hasher
-    ) -> None:
+    def install(self, *, scratch_root: pathlib.Path, destination: pathlib.Path) -> T_CO_Report:
         """
         Install the virtual dependencies into their destination.
 
@@ -615,6 +601,8 @@ if TYPE_CHECKING:
 
     P_VirtualDependencyMaker = VirtualDependencyMaker[P_Project, P_VirtualDependency]
     P_VirtualDependencyNamer = VirtualDependencyNamer
-    P_VirtualDependencyGenerator = VirtualDependencyGenerator[P_Project, P_VirtualDependency]
+    P_VirtualDependencyGenerator = VirtualDependencyGenerator[
+        P_Project, P_VirtualDependency, P_Report
+    ]
     P_VirtualDependencySummary = VirtualDependencySummary
-    P_GeneratedVirtualDependencies = GeneratedVirtualDependencies[P_VirtualDependency]
+    P_GeneratedVirtualDependencies = GeneratedVirtualDependencies[P_VirtualDependency, P_Report]

--- a/extended_mypy_django_plugin/django_analysis/protocols.py
+++ b/extended_mypy_django_plugin/django_analysis/protocols.py
@@ -473,6 +473,34 @@ class ReportMaker(Protocol[T_CO_Report]):
     ) -> T_CO_Report: ...
 
 
+class WrittenVirtualDependency(Protocol[T_CO_Report]):
+    @property
+    def content(self) -> str:
+        """
+        The string representing the content of the virtual dependency
+        """
+
+    @property
+    def summary_hash(self) -> str | None:
+        """
+        A hash representing the state of the dependency
+
+        This should be None if the module is not installed
+        """
+
+    @property
+    def report(self) -> T_CO_Report:
+        """
+        The report representing the information in the content
+        """
+
+    @property
+    def virtual_import_path(self) -> ImportPath:
+        """
+        The import path to this virtual dependency
+        """
+
+
 class VirtualDependencyScribe(Protocol[T_CO_VirtualDependency, T_CO_Report]):
     """
     Used to generate the on disk representation of a virtual dependency along with the information
@@ -491,11 +519,9 @@ class VirtualDependencyScribe(Protocol[T_CO_VirtualDependency, T_CO_Report]):
         Used to create the report object
         """
 
-    def generate_report(self) -> tuple[str, T_CO_Report, ImportPath]:
+    def generate_report(self) -> WrittenVirtualDependency[T_CO_Report]:
         """
         Create the content for a virtual dependency and a report of the information in that content
-
-        Should return (content, report, virtual_import_path)
         """
 
 
@@ -515,15 +541,20 @@ class ReportInstaller(Protocol):
     """
 
     def write_report(
-        self, *, scratch_root: pathlib.Path, virtual_import_path: ImportPath, content: str
+        self,
+        *,
+        scratch_root: pathlib.Path,
+        virtual_import_path: ImportPath,
+        content: str,
+        summary_hash: str | None,
     ) -> None:
         """
         Write a single report to the scratch path
         """
 
-    def install_reports(self, scratch_path: pathlib.Path, destination: pathlib.Path) -> None:
+    def install_reports(self, *, scratch_root: pathlib.Path, destination: pathlib.Path) -> None:
         """
-        Copy reports from scratch_path into the destination when the reports on the destination
+        Copy reports from scratch_root into the destination when the reports on the destination
         are different to the reports in the scratch path.
 
         Also, delete redundant reports from destination
@@ -596,6 +627,7 @@ if TYPE_CHECKING:
     P_ReportCombiner = ReportCombiner[P_Report]
     P_ReportCombinerMaker = ReportCombinerMaker[P_Report]
     P_VirtualDependencyScribe = VirtualDependencyScribe[P_VirtualDependency, P_Report]
+    P_WrittenVirtualDependency = WrittenVirtualDependency[P_Report]
     P_VirtualDependencyScribeMaker = VirtualDependencyScribeMaker[P_VirtualDependency, P_Report]
     P_ReportFactory = ReportFactory[P_VirtualDependency, P_Report]
 

--- a/extended_mypy_django_plugin/django_analysis/protocols.py
+++ b/extended_mypy_django_plugin/django_analysis/protocols.py
@@ -317,9 +317,9 @@ class VirtualDependencyMaker(Protocol[T_Project, T_CO_VirtualDependency]):
     ) -> T_CO_VirtualDependency: ...
 
 
-class VirtualDependencyFolder(Protocol[T_Project, T_CO_VirtualDependency]):
+class VirtualDependencyGenerator(Protocol[T_Project, T_CO_VirtualDependency]):
     """
-    Object that manages the folder containing the on disk virtual dependencies
+    Object that generates the objects representing the virtual dependencies
     """
 
     @property
@@ -452,6 +452,6 @@ if TYPE_CHECKING:
     P_VirtualDependency = VirtualDependency
     P_VirtualDependencyMaker = VirtualDependencyMaker[P_Project, P_VirtualDependency]
     P_VirtualDependencyNamer = VirtualDependencyNamer
-    P_VirtualDependencyFolder = VirtualDependencyFolder[P_Project, P_VirtualDependency]
+    P_VirtualDependencyGenerator = VirtualDependencyGenerator[P_Project, P_VirtualDependency]
     P_VirtualDependencySummary = VirtualDependencySummary
     P_GeneratedVirtualDependencies = GeneratedVirtualDependencies[P_VirtualDependency]

--- a/extended_mypy_django_plugin/django_analysis/protocols.py
+++ b/extended_mypy_django_plugin/django_analysis/protocols.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
 T_Project = TypeVar("T_Project", bound="P_Project")
 T_Report = TypeVar("T_Report", bound="P_Report")
 T_CO_Report = TypeVar("T_CO_Report", bound="P_Report", covariant=True)
+T_VirtualDependency = TypeVar("T_VirtualDependency", bound="P_VirtualDependency")
 T_CO_VirtualDependency = TypeVar(
     "T_CO_VirtualDependency", bound="P_VirtualDependency", covariant=True
 )
@@ -486,6 +487,42 @@ class ReportMaker(Protocol[T_CO_Report]):
     ) -> T_CO_Report: ...
 
 
+class VirtualDependencyScribe(Protocol[T_CO_VirtualDependency, T_CO_Report]):
+    """
+    Used to generate the on disk representation of a virtual dependency along with the information
+    contained in that dependency
+    """
+
+    @property
+    def virtual_dependency(self) -> T_CO_VirtualDependency:
+        """
+        The virtual dependency to create a report from
+        """
+
+    @property
+    def report_maker(self) -> ReportMaker[T_CO_Report]:
+        """
+        Used to create the report object
+        """
+
+    def generate_report(self) -> tuple[str, T_CO_Report, ImportPath]:
+        """
+        Create the content for a virtual dependency and a report of the information in that content
+
+        Should return (content, report, virtual_import_path)
+        """
+
+
+class VirtualDependencyScribeMaker(Protocol[T_VirtualDependency, T_CO_Report]):
+    """
+    Factory to make a VirtualDependencyScribe
+    """
+
+    def __call__(
+        self, *, virtual_dependency: T_VirtualDependency
+    ) -> VirtualDependencyScribe[T_VirtualDependency, T_CO_Report]: ...
+
+
 class ReportCombiner(Protocol[T_CO_Report]):
     """
     Used to combine many reports into one
@@ -530,6 +567,8 @@ if TYPE_CHECKING:
     P_ReportMaker = ReportMaker[P_Report]
     P_ReportCombiner = ReportCombiner[P_Report]
     P_ReportCombinerMaker = ReportCombinerMaker[P_Report]
+    P_VirtualDependencyScribe = VirtualDependencyScribe[P_VirtualDependency, P_Report]
+    P_VirtualDependencyScribeMaker = VirtualDependencyScribeMaker[P_VirtualDependency, P_Report]
 
     P_VirtualDependencyMaker = VirtualDependencyMaker[P_Project, P_VirtualDependency]
     P_VirtualDependencyNamer = VirtualDependencyNamer

--- a/extended_mypy_django_plugin/django_analysis/virtual_dependencies/__init__.py
+++ b/extended_mypy_django_plugin/django_analysis/virtual_dependencies/__init__.py
@@ -1,12 +1,21 @@
 from .dependency import VirtualDependency, VirtualDependencySummary
 from .folder import GeneratedVirtualDependencies, VirtualDependencyGenerator
 from .namer import VirtualDependencyNamer
-from .report import Report, ReportCombiner, ReportInstaller, VirtualDependencyScribe
+from .report import (
+    Report,
+    ReportCombiner,
+    ReportFactory,
+    ReportInstaller,
+    VirtualDependencyScribe,
+    make_report_factory,
+)
 
 __all__ = [
     "Report",
+    "ReportFactory",
     "ReportCombiner",
     "ReportInstaller",
+    "make_report_factory",
     "VirtualDependencyNamer",
     "VirtualDependencyScribe",
     "VirtualDependency",

--- a/extended_mypy_django_plugin/django_analysis/virtual_dependencies/__init__.py
+++ b/extended_mypy_django_plugin/django_analysis/virtual_dependencies/__init__.py
@@ -1,11 +1,12 @@
 from .dependency import VirtualDependency, VirtualDependencySummary
 from .folder import GeneratedVirtualDependencies, VirtualDependencyGenerator
 from .namer import VirtualDependencyNamer
-from .report import Report, ReportCombiner, VirtualDependencyScribe
+from .report import Report, ReportCombiner, ReportInstaller, VirtualDependencyScribe
 
 __all__ = [
     "Report",
     "ReportCombiner",
+    "ReportInstaller",
     "VirtualDependencyNamer",
     "VirtualDependencyScribe",
     "VirtualDependency",

--- a/extended_mypy_django_plugin/django_analysis/virtual_dependencies/__init__.py
+++ b/extended_mypy_django_plugin/django_analysis/virtual_dependencies/__init__.py
@@ -1,8 +1,11 @@
 from .dependency import VirtualDependency, VirtualDependencySummary
 from .folder import GeneratedVirtualDependencies, VirtualDependencyGenerator
 from .namer import VirtualDependencyNamer
+from .report import Report, ReportCombiner
 
 __all__ = [
+    "Report",
+    "ReportCombiner",
     "VirtualDependencyNamer",
     "VirtualDependency",
     "VirtualDependencySummary",

--- a/extended_mypy_django_plugin/django_analysis/virtual_dependencies/__init__.py
+++ b/extended_mypy_django_plugin/django_analysis/virtual_dependencies/__init__.py
@@ -1,12 +1,13 @@
 from .dependency import VirtualDependency, VirtualDependencySummary
 from .folder import GeneratedVirtualDependencies, VirtualDependencyGenerator
 from .namer import VirtualDependencyNamer
-from .report import Report, ReportCombiner
+from .report import Report, ReportCombiner, VirtualDependencyScribe
 
 __all__ = [
     "Report",
     "ReportCombiner",
     "VirtualDependencyNamer",
+    "VirtualDependencyScribe",
     "VirtualDependency",
     "VirtualDependencySummary",
     "VirtualDependencyGenerator",

--- a/extended_mypy_django_plugin/django_analysis/virtual_dependencies/__init__.py
+++ b/extended_mypy_django_plugin/django_analysis/virtual_dependencies/__init__.py
@@ -1,11 +1,11 @@
 from .dependency import VirtualDependency, VirtualDependencySummary
-from .folder import GeneratedVirtualDependencies, VirtualDependencyFolder
+from .folder import GeneratedVirtualDependencies, VirtualDependencyGenerator
 from .namer import VirtualDependencyNamer
 
 __all__ = [
     "VirtualDependencyNamer",
     "VirtualDependency",
     "VirtualDependencySummary",
-    "VirtualDependencyFolder",
+    "VirtualDependencyGenerator",
     "GeneratedVirtualDependencies",
 ]

--- a/extended_mypy_django_plugin/django_analysis/virtual_dependencies/folder.py
+++ b/extended_mypy_django_plugin/django_analysis/virtual_dependencies/folder.py
@@ -7,7 +7,7 @@ from . import dependency
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
-class VirtualDependencyFolder(Generic[protocols.T_Project, protocols.T_CO_VirtualDependency]):
+class VirtualDependencyGenerator(Generic[protocols.T_Project, protocols.T_CO_VirtualDependency]):
     discovered_project: protocols.Discovered[protocols.T_Project]
     virtual_dependency_maker: protocols.VirtualDependencyMaker[
         protocols.T_Project, protocols.T_CO_VirtualDependency
@@ -35,21 +35,21 @@ class GeneratedVirtualDependencies(Generic[protocols.T_CO_VirtualDependency]):
 
 
 if TYPE_CHECKING:
-    C_VirtualDependencyFolder = VirtualDependencyFolder[
+    C_VirtualDependencyGenerator = VirtualDependencyGenerator[
         project.C_Project, dependency.C_VirtualDependency
     ]
     C_GeneratedVirtualDependencies = GeneratedVirtualDependencies[dependency.C_VirtualDependency]
 
-    _VDN: protocols.P_VirtualDependencyFolder = cast(
-        VirtualDependencyFolder[protocols.P_Project, protocols.P_VirtualDependency], None
+    _VDN: protocols.P_VirtualDependencyGenerator = cast(
+        VirtualDependencyGenerator[protocols.P_Project, protocols.P_VirtualDependency], None
     )
     _GVD: protocols.P_GeneratedVirtualDependencies = cast(
         GeneratedVirtualDependencies[protocols.P_VirtualDependency], None
     )
 
-    _CVDN: protocols.VirtualDependencyFolder[project.C_Project, dependency.C_VirtualDependency] = (
-        cast(C_VirtualDependencyFolder, None)
-    )
+    _CVDN: protocols.VirtualDependencyGenerator[
+        project.C_Project, dependency.C_VirtualDependency
+    ] = cast(C_VirtualDependencyGenerator, None)
     _CGVD: protocols.GeneratedVirtualDependencies[dependency.C_VirtualDependency] = cast(
         C_GeneratedVirtualDependencies, None
     )

--- a/extended_mypy_django_plugin/django_analysis/virtual_dependencies/folder.py
+++ b/extended_mypy_django_plugin/django_analysis/virtual_dependencies/folder.py
@@ -3,53 +3,71 @@ import pathlib
 from typing import TYPE_CHECKING, Generic, cast
 
 from .. import project, protocols
-from . import dependency
+from . import dependency, report
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
-class VirtualDependencyGenerator(Generic[protocols.T_Project, protocols.T_CO_VirtualDependency]):
-    discovered_project: protocols.Discovered[protocols.T_Project]
+class VirtualDependencyGenerator(
+    Generic[protocols.T_Project, protocols.T_CO_VirtualDependency, protocols.T_Report]
+):
+    report_factory: protocols.ReportFactory[protocols.T_CO_VirtualDependency, protocols.T_Report]
     virtual_dependency_maker: protocols.VirtualDependencyMaker[
         protocols.T_Project, protocols.T_CO_VirtualDependency
     ]
 
-    def generate(self) -> protocols.GeneratedVirtualDependencies[protocols.T_CO_VirtualDependency]:
+    def __call__(
+        self, *, discovered_project: protocols.Discovered[protocols.T_Project]
+    ) -> protocols.GeneratedVirtualDependencies[
+        protocols.T_CO_VirtualDependency, protocols.T_Report
+    ]:
         return GeneratedVirtualDependencies(
+            report_factory=self.report_factory,
             virtual_dependencies={
                 import_path: self.virtual_dependency_maker(
-                    discovered_project=self.discovered_project, module=module
+                    discovered_project=discovered_project, module=module
                 )
-                for import_path, module in self.discovered_project.installed_models_modules.items()
-            }
+                for import_path, module in discovered_project.installed_models_modules.items()
+            },
         )
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
-class GeneratedVirtualDependencies(Generic[protocols.T_CO_VirtualDependency]):
-    virtual_dependencies: protocols.VirtualDependencyMap[protocols.T_CO_VirtualDependency]
+class GeneratedVirtualDependencies(Generic[protocols.T_VirtualDependency, protocols.T_Report]):
+    report_factory: protocols.ReportFactory[protocols.T_VirtualDependency, protocols.T_Report]
+    virtual_dependencies: protocols.VirtualDependencyMap[protocols.T_VirtualDependency]
 
     def install(
-        self, *, scratch_root: pathlib.Path, destination: pathlib.Path, hasher: protocols.Hasher
-    ) -> None:
-        pass
+        self, *, scratch_root: pathlib.Path, destination: pathlib.Path
+    ) -> protocols.T_Report:
+        return self.report_factory.report_maker(
+            concrete_annotations={},
+            concrete_querysets={},
+            report_import_path={},
+            related_report_import_paths={},
+        )
 
 
 if TYPE_CHECKING:
     C_VirtualDependencyGenerator = VirtualDependencyGenerator[
-        project.C_Project, dependency.C_VirtualDependency
+        project.C_Project, dependency.C_VirtualDependency, report.C_Report
     ]
-    C_GeneratedVirtualDependencies = GeneratedVirtualDependencies[dependency.C_VirtualDependency]
+    C_GeneratedVirtualDependencies = GeneratedVirtualDependencies[
+        dependency.C_VirtualDependency, report.C_Report
+    ]
 
     _VDN: protocols.P_VirtualDependencyGenerator = cast(
-        VirtualDependencyGenerator[protocols.P_Project, protocols.P_VirtualDependency], None
+        VirtualDependencyGenerator[
+            protocols.P_Project, protocols.P_VirtualDependency, protocols.P_Report
+        ],
+        None,
     )
     _GVD: protocols.P_GeneratedVirtualDependencies = cast(
-        GeneratedVirtualDependencies[protocols.P_VirtualDependency], None
+        GeneratedVirtualDependencies[protocols.P_VirtualDependency, protocols.P_Report], None
     )
 
     _CVDN: protocols.VirtualDependencyGenerator[
-        project.C_Project, dependency.C_VirtualDependency
+        project.C_Project, dependency.C_VirtualDependency, report.C_Report
     ] = cast(C_VirtualDependencyGenerator, None)
-    _CGVD: protocols.GeneratedVirtualDependencies[dependency.C_VirtualDependency] = cast(
-        C_GeneratedVirtualDependencies, None
-    )
+    _CGVD: protocols.GeneratedVirtualDependencies[
+        dependency.C_VirtualDependency, report.C_Report
+    ] = cast(C_GeneratedVirtualDependencies, None)

--- a/extended_mypy_django_plugin/django_analysis/virtual_dependencies/report.py
+++ b/extended_mypy_django_plugin/django_analysis/virtual_dependencies/report.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import dataclasses
+from collections.abc import Mapping, Sequence
+from typing import TYPE_CHECKING, Generic, cast
+
+from .. import protocols
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class Report:
+    concrete_annotations: Mapping[protocols.ImportPath, protocols.ImportPath]
+    concrete_querysets: Mapping[protocols.ImportPath, protocols.ImportPath]
+    report_import_path: Mapping[protocols.ImportPath, protocols.ImportPath]
+    related_report_import_paths: Mapping[protocols.ImportPath, Sequence[protocols.ImportPath]]
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class ReportCombiner(Generic[protocols.T_Report]):
+    reports: Sequence[protocols.T_Report]
+    report_maker: protocols.ReportMaker[protocols.T_Report]
+
+    def combine(self) -> protocols.T_Report:
+        concrete_annotations: dict[protocols.ImportPath, protocols.ImportPath] = {}
+        concrete_querysets: dict[protocols.ImportPath, protocols.ImportPath] = {}
+        report_import_path: dict[protocols.ImportPath, protocols.ImportPath] = {}
+        related_report_import_paths: dict[
+            protocols.ImportPath, Sequence[protocols.ImportPath]
+        ] = {}
+
+        for report in self.reports:
+            concrete_annotations.update(report.concrete_annotations)
+            concrete_querysets.update(report.concrete_querysets)
+            report_import_path.update(report.report_import_path)
+            related_report_import_paths.update(report.related_report_import_paths)
+
+        return self.report_maker(
+            concrete_annotations=concrete_annotations,
+            concrete_querysets=concrete_querysets,
+            report_import_path=report_import_path,
+            related_report_import_paths=related_report_import_paths,
+        )
+
+
+if TYPE_CHECKING:
+    C_Report = Report
+    C_ReportCombiner = ReportCombiner[C_Report]
+
+    _R: protocols.Report = cast(Report, None)
+
+    _CRC: protocols.ReportCombiner[C_Report] = cast(C_ReportCombiner, None)
+    _CRM: protocols.ReportMaker[C_Report] = Report

--- a/extended_mypy_django_plugin/django_analysis/virtual_dependencies/report.py
+++ b/extended_mypy_django_plugin/django_analysis/virtual_dependencies/report.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
+import pathlib
 from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, Generic, cast
 
@@ -61,15 +62,32 @@ class ReportCombiner(Generic[protocols.T_Report]):
         )
 
 
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class ReportInstaller:
+    def write_report(
+        self,
+        *,
+        scratch_root: pathlib.Path,
+        virtual_import_path: protocols.ImportPath,
+        content: str,
+    ) -> None:
+        pass
+
+    def install_reports(self, scratch_path: pathlib.Path, destination: pathlib.Path) -> None:
+        pass
+
+
 if TYPE_CHECKING:
     C_Report = Report
     C_ReportCombiner = ReportCombiner[C_Report]
+    C_ReportInstaller = ReportInstaller
     C_VirtualDependencyScribe = VirtualDependencyScribe[project.C_Project, C_Report]
 
     _R: protocols.Report = cast(Report, None)
     _RM: protocols.P_VirtualDependencyScribe = cast(
         VirtualDependencyScribe[protocols.P_Project, protocols.P_Report], None
     )
+    _RI: protocols.P_ReportInstaller = cast(ReportInstaller, None)
 
     _CVDS: protocols.VirtualDependencyScribe[dependency.C_VirtualDependency, C_Report] = cast(
         VirtualDependencyScribe[project.C_Project, C_Report], None

--- a/tests/django_analysis/virtual_dependencies/test_folder.py
+++ b/tests/django_analysis/virtual_dependencies/test_folder.py
@@ -36,10 +36,13 @@ class TestVirtualDependencyGenerator:
             make_differentiator=lambda: "__differentiated__",
         )
 
-        generated = virtual_dependencies.VirtualDependencyGenerator(
+        report_factory = virtual_dependencies.make_report_factory(
+            hasher=adler32_hash,
             discovered_project=discovered_django_example,
-            virtual_dependency_maker=virtual_dependency_maker,
-        ).generate()
+        )
+        generated = virtual_dependencies.VirtualDependencyGenerator(
+            report_factory=report_factory, virtual_dependency_maker=virtual_dependency_maker
+        )(discovered_project=discovered_django_example)
 
         def IsModule(import_path: str) -> protocols.Module:
             return discovered_django_example.installed_models_modules[ImportPath(import_path)]
@@ -48,6 +51,7 @@ class TestVirtualDependencyGenerator:
             return discovered_django_example.all_models[ImportPath(import_path)]
 
         assert generated == virtual_dependencies.GeneratedVirtualDependencies(
+            report_factory=report_factory,
             virtual_dependencies={
                 ImportPath("django.contrib.admin.models"): CustomVirtualDependency(
                     module=IsModule("django.contrib.admin.models"),
@@ -316,5 +320,5 @@ class TestVirtualDependencyGenerator:
                         ],
                     },
                 ),
-            }
+            },
         )

--- a/tests/django_analysis/virtual_dependencies/test_folder.py
+++ b/tests/django_analysis/virtual_dependencies/test_folder.py
@@ -10,7 +10,7 @@ from extended_mypy_django_plugin.django_analysis import (
 )
 
 
-class TestVirtualDependencyFolder:
+class TestVirtualDependencyGenerator:
     def test_it_can_generate_virtual_dependencies(
         self, discovered_django_example: protocols.Discovered[Project]
     ) -> None:
@@ -36,7 +36,7 @@ class TestVirtualDependencyFolder:
             make_differentiator=lambda: "__differentiated__",
         )
 
-        generated = virtual_dependencies.VirtualDependencyFolder(
+        generated = virtual_dependencies.VirtualDependencyGenerator(
             discovered_project=discovered_django_example,
             virtual_dependency_maker=virtual_dependency_maker,
         ).generate()

--- a/tests/django_analysis/virtual_dependencies/test_report.py
+++ b/tests/django_analysis/virtual_dependencies/test_report.py
@@ -1,0 +1,86 @@
+from extended_mypy_django_plugin.django_analysis import ImportPath, virtual_dependencies
+
+
+class TestCombiningReports:
+    def test_it_can_combine_reports(self) -> None:
+        report1 = virtual_dependencies.Report(
+            concrete_annotations={
+                ImportPath("P1"): ImportPath("CP1"),
+                ImportPath("C1"): ImportPath("CC1"),
+            },
+            concrete_querysets={
+                ImportPath("P1"): ImportPath("CP1QS"),
+                ImportPath("C1"): ImportPath("CC1QS"),
+            },
+            report_import_path={
+                ImportPath("M1"): ImportPath("VM1"),
+            },
+            related_report_import_paths={
+                ImportPath("M1"): [ImportPath("VM1"), ImportPath("VM2")],
+            },
+        )
+        report2 = virtual_dependencies.Report(
+            concrete_annotations={
+                ImportPath("C2"): ImportPath("CC2"),
+            },
+            concrete_querysets={
+                ImportPath("C2"): ImportPath("C2QS"),
+            },
+            report_import_path={
+                ImportPath("M2"): ImportPath("VM2"),
+            },
+            related_report_import_paths={
+                ImportPath("M2"): [ImportPath("VM1"), ImportPath("VM2")],
+            },
+        )
+        report3 = virtual_dependencies.Report(
+            concrete_annotations={
+                ImportPath("P2"): ImportPath("CP2"),
+                ImportPath("C3"): ImportPath("CC3"),
+                ImportPath("C4"): ImportPath("CC4"),
+            },
+            concrete_querysets={
+                ImportPath("P2"): ImportPath("CP2QS"),
+                ImportPath("C3"): ImportPath("CC3QS"),
+                ImportPath("C4"): ImportPath("CC4QS"),
+            },
+            report_import_path={
+                ImportPath("M3"): ImportPath("VM3"),
+            },
+            related_report_import_paths={
+                ImportPath("M3"): [ImportPath("VM3")],
+            },
+        )
+
+        final_report = virtual_dependencies.ReportCombiner(
+            report_maker=virtual_dependencies.Report, reports=(report1, report2, report3)
+        ).combine()
+
+        assert final_report == virtual_dependencies.Report(
+            concrete_annotations={
+                ImportPath("P1"): ImportPath("CP1"),
+                ImportPath("C1"): ImportPath("CC1"),
+                ImportPath("C2"): ImportPath("CC2"),
+                ImportPath("P2"): ImportPath("CP2"),
+                ImportPath("C3"): ImportPath("CC3"),
+                ImportPath("C4"): ImportPath("CC4"),
+            },
+            concrete_querysets={
+                ImportPath("P1"): ImportPath("CP1QS"),
+                ImportPath("C1"): ImportPath("CC1QS"),
+                ImportPath("C2"): ImportPath("C2QS"),
+                ImportPath("P2"): ImportPath("CP2QS"),
+                ImportPath("C3"): ImportPath("CC3QS"),
+                ImportPath("C4"): ImportPath("CC4QS"),
+            },
+            report_import_path={
+                ImportPath("M1"): ImportPath("VM1"),
+                ImportPath("M2"): ImportPath("VM2"),
+                ImportPath("M3"): ImportPath("VM3"),
+            },
+            related_report_import_paths={
+                ImportPath("M1"): [ImportPath("VM1"), ImportPath("VM2")],
+                ImportPath("M2"): [ImportPath("VM1"), ImportPath("VM2")],
+                ImportPath("M3"): [ImportPath("VM3")],
+            },
+        )


### PR DESCRIPTION
A key part of the problem the django analysis is solving is being able to resolve concrete annotations by pointing at virtual dependencies rather than resolving inside the plugin itself.

To make this super super easy, this change makes it so that generating the virtual dependencies produces a report that represents the information the mypy plugin will end up needing.