### PR TITLE
Refining API for generating virtual dependencies

### DIFF
--- a/extended_mypy_django_plugin/django_analysis/discovery/__init__.py
+++ b/extended_mypy_django_plugin/django_analysis/discovery/__init__.py
@@ -1,12 +1,13 @@
 from .concrete_models import ConcreteModelsDiscovery
 from .container import Discovery
-from .import_path import ImportPath
+from .import_path import ImportPath, InvalidImportPath
 from .known_models import DefaultInstalledModulesDiscovery
 from .settings_types import NaiveSettingsTypesDiscovery
 
 __all__ = [
     "Discovery",
     "ImportPath",
+    "InvalidImportPath",
     "DefaultInstalledModulesDiscovery",
     "ConcreteModelsDiscovery",
     "NaiveSettingsTypesDiscovery",

--- a/extended_mypy_django_plugin/django_analysis/discovery/import_path.py
+++ b/extended_mypy_django_plugin/django_analysis/discovery/import_path.py
@@ -3,19 +3,41 @@ import types
 from .. import protocols
 
 
+class InvalidImportPath(ValueError):
+    pass
+
+
 class ImportPathHelper:
+    """
+    Helper for creating strings that are valid protocols.ImportPath objects
+    """
+
     def from_cls(self, cls: type) -> protocols.ImportPath:
+        """
+        Given some class return an import path to it
+        """
         return self(f"{cls.__module__}.{cls.__qualname__}")
 
     def cls_module(self, cls: type) -> protocols.ImportPath:
+        """
+        Given some cls return an import path to the module that defined it
+        """
         return self(cls.__module__)
 
     def from_module(self, module: types.ModuleType) -> protocols.ImportPath:
+        """
+        Given some module return an import path to it
+        """
         return self(module.__name__)
 
     def __call__(self, path: str) -> protocols.ImportPath:
+        """
+        Return a string as a protocols.ImportPath type.
+
+        If the string is not a valid import then a InvalidImportPath will be raised
+        """
         if not all(part and part.isidentifier() for part in path.split(".")):
-            raise RuntimeError(f"Provided path was not a valid python import path: '{path}'")
+            raise InvalidImportPath(f"Provided path was not a valid python import path: '{path}'")
         return protocols.ImportPath(path)
 
 

--- a/extended_mypy_django_plugin/django_analysis/discovery/import_path.py
+++ b/extended_mypy_django_plugin/django_analysis/discovery/import_path.py
@@ -30,6 +30,21 @@ class ImportPathHelper:
         """
         return self(module.__name__)
 
+    def split(
+        self, path: protocols.ImportPath
+    ) -> tuple[protocols.ImportPath, protocols.ImportPath]:
+        """
+        Split a path into it's namespace and name.
+
+        So `my.code.Thing` splits into (`my.code`, `Thing`)
+
+        If the path is not namespaced then a InvalidImportPath will be raised
+        """
+        if "." not in path:
+            raise InvalidImportPath(f"Provided path was not namespaced: '{path}'")
+        namespace, name = path.rsplit(".", 1)
+        return protocols.ImportPath(namespace), protocols.ImportPath(name)
+
     def __call__(self, path: str) -> protocols.ImportPath:
         """
         Return a string as a protocols.ImportPath type.

--- a/extended_mypy_django_plugin/django_analysis/protocols.py
+++ b/extended_mypy_django_plugin/django_analysis/protocols.py
@@ -431,30 +431,27 @@ class Report(Protocol):
     information from the virtual dependencies
     """
 
-    @property
-    def concrete_annotations(self) -> Mapping[ImportPath, ImportPath]:
+    def register_module(
+        self,
+        *,
+        module_import_path: ImportPath,
+        virtual_import_path: ImportPath,
+    ) -> None:
         """
-        A map of full import path for a model to the import path of the equivalent typealias
-        representing the concrete children of that model
-        """
-
-    @property
-    def concrete_querysets(self) -> Mapping[ImportPath, ImportPath]:
-        """
-        A map of full import path for a model to the import path of the equivalent typealias
-        representing the concrete querysets of that model
+        Register a module to it's virtual path
         """
 
-    @property
-    def report_import_path(self) -> Mapping[ImportPath, ImportPath]:
+    def register_model(
+        self,
+        *,
+        model_import_path: ImportPath,
+        virtual_import_path: ImportPath,
+        concrete_name: str,
+        concrete_queryset_name: str,
+        concrete_models: Sequence[Model],
+    ) -> None:
         """
-        A map of full import path for a module to the virtual dependency for that module
-        """
-
-    @property
-    def related_report_import_paths(self) -> Mapping[ImportPath, Sequence[ImportPath]]:
-        """
-        A map of related report import paths for any given module
+        Register details about a model
         """
 
 
@@ -463,14 +460,7 @@ class ReportMaker(Protocol[T_CO_Report]):
     Used to construct a report
     """
 
-    def __call__(
-        self,
-        *,
-        concrete_annotations: Mapping[ImportPath, ImportPath],
-        concrete_querysets: Mapping[ImportPath, ImportPath],
-        report_import_path: Mapping[ImportPath, ImportPath],
-        related_report_import_paths: Mapping[ImportPath, Sequence[ImportPath]],
-    ) -> T_CO_Report: ...
+    def __call__(self) -> T_CO_Report: ...
 
 
 class WrittenVirtualDependency(Protocol[T_CO_Report]):

--- a/extended_mypy_django_plugin/django_analysis/virtual_dependencies/__init__.py
+++ b/extended_mypy_django_plugin/django_analysis/virtual_dependencies/__init__.py
@@ -1,5 +1,5 @@
 from .dependency import VirtualDependency, VirtualDependencySummary
-from .folder import GeneratedVirtualDependencies, VirtualDependencyGenerator
+from .folder import VirtualDependencyGenerator, VirtualDependencyInstaller
 from .namer import VirtualDependencyNamer
 from .report import (
     Report,
@@ -21,5 +21,5 @@ __all__ = [
     "VirtualDependency",
     "VirtualDependencySummary",
     "VirtualDependencyGenerator",
-    "GeneratedVirtualDependencies",
+    "VirtualDependencyInstaller",
 ]

--- a/extended_mypy_django_plugin/django_analysis/virtual_dependencies/folder.py
+++ b/extended_mypy_django_plugin/django_analysis/virtual_dependencies/folder.py
@@ -39,12 +39,7 @@ class GeneratedVirtualDependencies(Generic[protocols.T_VirtualDependency, protoc
     def install(
         self, *, scratch_root: pathlib.Path, destination: pathlib.Path
     ) -> protocols.T_Report:
-        return self.report_factory.report_maker(
-            concrete_annotations={},
-            concrete_querysets={},
-            report_import_path={},
-            related_report_import_paths={},
-        )
+        return self.report_factory.report_maker()
 
 
 if TYPE_CHECKING:

--- a/extended_mypy_django_plugin/django_analysis/virtual_dependencies/folder.py
+++ b/extended_mypy_django_plugin/django_analysis/virtual_dependencies/folder.py
@@ -7,62 +7,55 @@ from . import dependency, report
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
-class VirtualDependencyGenerator(
-    Generic[protocols.T_Project, protocols.T_CO_VirtualDependency, protocols.T_Report]
-):
-    report_factory: protocols.ReportFactory[protocols.T_CO_VirtualDependency, protocols.T_Report]
+class VirtualDependencyGenerator(Generic[protocols.T_Project, protocols.T_VirtualDependency]):
     virtual_dependency_maker: protocols.VirtualDependencyMaker[
-        protocols.T_Project, protocols.T_CO_VirtualDependency
+        protocols.T_Project, protocols.T_VirtualDependency
     ]
 
     def __call__(
         self, *, discovered_project: protocols.Discovered[protocols.T_Project]
-    ) -> protocols.GeneratedVirtualDependencies[
-        protocols.T_CO_VirtualDependency, protocols.T_Report
-    ]:
-        return GeneratedVirtualDependencies(
-            report_factory=self.report_factory,
-            virtual_dependencies={
-                import_path: self.virtual_dependency_maker(
-                    discovered_project=discovered_project, module=module
-                )
-                for import_path, module in discovered_project.installed_models_modules.items()
-            },
-        )
+    ) -> protocols.VirtualDependencyMap[protocols.T_VirtualDependency]:
+        return {
+            import_path: self.virtual_dependency_maker(
+                discovered_project=discovered_project, module=module
+            )
+            for import_path, module in discovered_project.installed_models_modules.items()
+        }
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
-class GeneratedVirtualDependencies(Generic[protocols.T_VirtualDependency, protocols.T_Report]):
-    report_factory: protocols.ReportFactory[protocols.T_VirtualDependency, protocols.T_Report]
+class VirtualDependencyInstaller(Generic[protocols.T_VirtualDependency, protocols.T_Report]):
     virtual_dependencies: protocols.VirtualDependencyMap[protocols.T_VirtualDependency]
 
-    def install(
-        self, *, scratch_root: pathlib.Path, destination: pathlib.Path
+    def __call__(
+        self,
+        *,
+        scratch_root: pathlib.Path,
+        destination: pathlib.Path,
+        report_factory: protocols.ReportFactory[protocols.T_VirtualDependency, protocols.T_Report],
     ) -> protocols.T_Report:
-        return self.report_factory.report_maker()
+        return report_factory.report_maker()
 
 
 if TYPE_CHECKING:
     C_VirtualDependencyGenerator = VirtualDependencyGenerator[
-        project.C_Project, dependency.C_VirtualDependency, report.C_Report
+        project.C_Project, dependency.C_VirtualDependency
     ]
-    C_GeneratedVirtualDependencies = GeneratedVirtualDependencies[
+    C_VirtualDependencyInstaller = VirtualDependencyInstaller[
         dependency.C_VirtualDependency, report.C_Report
     ]
 
     _VDN: protocols.P_VirtualDependencyGenerator = cast(
-        VirtualDependencyGenerator[
-            protocols.P_Project, protocols.P_VirtualDependency, protocols.P_Report
-        ],
+        VirtualDependencyGenerator[protocols.P_Project, protocols.P_VirtualDependency],
         None,
     )
-    _GVD: protocols.P_GeneratedVirtualDependencies = cast(
-        GeneratedVirtualDependencies[protocols.P_VirtualDependency, protocols.P_Report], None
+    _GVD: protocols.P_VirtualDependencyInstaller = cast(
+        VirtualDependencyInstaller[protocols.P_VirtualDependency, protocols.P_Report], None
     )
 
     _CVDN: protocols.VirtualDependencyGenerator[
-        project.C_Project, dependency.C_VirtualDependency, report.C_Report
+        project.C_Project, dependency.C_VirtualDependency
     ] = cast(C_VirtualDependencyGenerator, None)
-    _CGVD: protocols.GeneratedVirtualDependencies[
+    _CGVD: protocols.VirtualDependencyInstaller[
         dependency.C_VirtualDependency, report.C_Report
-    ] = cast(C_GeneratedVirtualDependencies, None)
+    ] = cast(C_VirtualDependencyInstaller, None)

--- a/tests/django_analysis/discovery/test_import_path.py
+++ b/tests/django_analysis/discovery/test_import_path.py
@@ -28,6 +28,20 @@ class TestImportPathHelper:
             == "extended_mypy_django_plugin.django_analysis.discovery.import_path"
         )
 
+    def test_can_split_an_import_path(self) -> None:
+        assert ImportPath.split(protocols.ImportPath("somewhere.nice")) == (
+            protocols.ImportPath("somewhere"),
+            protocols.ImportPath("nice"),
+        )
+        assert ImportPath.split(protocols.ImportPath("somewhere.else.that.is.good")) == (
+            protocols.ImportPath("somewhere.else.that.is"),
+            protocols.ImportPath("good"),
+        )
+
+    def test_complains_if_splitting_non_namespaced_import(self) -> None:
+        with pytest.raises(discovery.InvalidImportPath):
+            ImportPath.split(protocols.ImportPath("not_namespaced"))
+
     def test_turns_string_into_import_path(self) -> None:
         assert ImportPath("hello.there") == protocols.ImportPath("hello.there")
         assert ImportPath("place") == protocols.ImportPath("place")

--- a/tests/django_analysis/discovery/test_import_path.py
+++ b/tests/django_analysis/discovery/test_import_path.py
@@ -1,0 +1,48 @@
+import pytest
+
+from extended_mypy_django_plugin.django_analysis import ImportPath, discovery, protocols
+from extended_mypy_django_plugin.django_analysis.discovery.import_path import ImportPathHelper
+
+
+class TestImportPathHelper:
+    def test_an_instance_is_provided(self) -> None:
+        assert isinstance(ImportPath, ImportPathHelper)
+
+    def test_can_return_path_to_class(self) -> None:
+        assert (
+            ImportPath.from_cls(TestImportPathHelper)
+            == "tests.django_analysis.discovery.test_import_path.TestImportPathHelper"
+        )
+        assert (
+            ImportPath.from_cls(ImportPathHelper)
+            == "extended_mypy_django_plugin.django_analysis.discovery.import_path.ImportPathHelper"
+        )
+
+    def test_can_return_module_import_path_from_class(self) -> None:
+        assert (
+            ImportPath.cls_module(TestImportPathHelper)
+            == "tests.django_analysis.discovery.test_import_path"
+        )
+        assert (
+            ImportPath.cls_module(ImportPathHelper)
+            == "extended_mypy_django_plugin.django_analysis.discovery.import_path"
+        )
+
+    def test_turns_string_into_import_path(self) -> None:
+        assert ImportPath("hello.there") == protocols.ImportPath("hello.there")
+        assert ImportPath("place") == protocols.ImportPath("place")
+
+    @pytest.mark.parametrize(
+        "invalid",
+        (
+            pytest.param(".wat", id="starts_with_dot"),
+            pytest.param("stuff..things", id="double_dot"),
+            pytest.param("3stuff", id="starts_with_number"),
+            pytest.param("things-stuff", id="dashes_not_valid_identifier"),
+            pytest.param("", id="empty_string"),
+            pytest.param("%%%", id="another_invalid_identifier"),
+        ),
+    )
+    def test_complains_if_string_is_not_valid_import_path(self, invalid: str) -> None:
+        with pytest.raises(discovery.InvalidImportPath):
+            ImportPath(invalid)

--- a/tests/django_analysis/virtual_dependencies/test_folder.py
+++ b/tests/django_analysis/virtual_dependencies/test_folder.py
@@ -36,12 +36,8 @@ class TestVirtualDependencyGenerator:
             make_differentiator=lambda: "__differentiated__",
         )
 
-        report_factory = virtual_dependencies.make_report_factory(
-            hasher=adler32_hash,
-            discovered_project=discovered_django_example,
-        )
         generated = virtual_dependencies.VirtualDependencyGenerator(
-            report_factory=report_factory, virtual_dependency_maker=virtual_dependency_maker
+            virtual_dependency_maker=virtual_dependency_maker
         )(discovered_project=discovered_django_example)
 
         def IsModule(import_path: str) -> protocols.Module:
@@ -50,275 +46,272 @@ class TestVirtualDependencyGenerator:
         def IsModel(import_path: str) -> protocols.Model:
             return discovered_django_example.all_models[ImportPath(import_path)]
 
-        assert generated == virtual_dependencies.GeneratedVirtualDependencies(
-            report_factory=report_factory,
-            virtual_dependencies={
-                ImportPath("django.contrib.admin.models"): CustomVirtualDependency(
-                    module=IsModule("django.contrib.admin.models"),
-                    interface_differentiator="__differentiated__",
-                    summary=virtual_dependencies.VirtualDependencySummary(
-                        virtual_dependency_name=ImportPath("__virtual__.mod_2456226428"),
-                        module_import_path=ImportPath("django.contrib.admin.models"),
-                        installed_apps_hash="__hashed_installed_apps__",
-                        significant_info=["__significant__django.contrib.admin.models__"],
-                    ),
-                    all_related_models=[
-                        ImportPath("django.contrib.admin.models.LogEntry"),
-                        ImportPath("django.contrib.auth.models.User"),
-                        ImportPath("django.contrib.contenttypes.models.ContentType"),
-                    ],
-                    concrete_models={
-                        ImportPath("django.contrib.admin.models.LogEntry"): [
-                            IsModel("django.contrib.admin.models.LogEntry")
-                        ]
-                    },
+        assert generated == {
+            ImportPath("django.contrib.admin.models"): CustomVirtualDependency(
+                module=IsModule("django.contrib.admin.models"),
+                interface_differentiator="__differentiated__",
+                summary=virtual_dependencies.VirtualDependencySummary(
+                    virtual_dependency_name=ImportPath("__virtual__.mod_2456226428"),
+                    module_import_path=ImportPath("django.contrib.admin.models"),
+                    installed_apps_hash="__hashed_installed_apps__",
+                    significant_info=["__significant__django.contrib.admin.models__"],
                 ),
-                ImportPath("django.contrib.auth.base_user"): CustomVirtualDependency(
-                    module=IsModule("django.contrib.auth.base_user"),
-                    interface_differentiator="__differentiated__",
-                    summary=virtual_dependencies.VirtualDependencySummary(
-                        virtual_dependency_name=ImportPath("__virtual__.mod_2833058650"),
-                        module_import_path=ImportPath("django.contrib.auth.base_user"),
-                        installed_apps_hash="__hashed_installed_apps__",
-                        significant_info=["__significant__django.contrib.auth.base_user__"],
-                    ),
-                    all_related_models=[
-                        ImportPath("django.contrib.auth.base_user.AbstractBaseUser"),
-                    ],
-                    concrete_models={
-                        ImportPath("django.contrib.auth.base_user.AbstractBaseUser"): [
-                            IsModel("django.contrib.auth.models.User")
-                        ],
-                    },
+                all_related_models=[
+                    ImportPath("django.contrib.admin.models.LogEntry"),
+                    ImportPath("django.contrib.auth.models.User"),
+                    ImportPath("django.contrib.contenttypes.models.ContentType"),
+                ],
+                concrete_models={
+                    ImportPath("django.contrib.admin.models.LogEntry"): [
+                        IsModel("django.contrib.admin.models.LogEntry")
+                    ]
+                },
+            ),
+            ImportPath("django.contrib.auth.base_user"): CustomVirtualDependency(
+                module=IsModule("django.contrib.auth.base_user"),
+                interface_differentiator="__differentiated__",
+                summary=virtual_dependencies.VirtualDependencySummary(
+                    virtual_dependency_name=ImportPath("__virtual__.mod_2833058650"),
+                    module_import_path=ImportPath("django.contrib.auth.base_user"),
+                    installed_apps_hash="__hashed_installed_apps__",
+                    significant_info=["__significant__django.contrib.auth.base_user__"],
                 ),
-                ImportPath("django.contrib.auth.models"): CustomVirtualDependency(
-                    module=IsModule("django.contrib.auth.models"),
-                    interface_differentiator="__differentiated__",
-                    summary=virtual_dependencies.VirtualDependencySummary(
-                        virtual_dependency_name=ImportPath("__virtual__.mod_2289830437"),
-                        module_import_path=ImportPath("django.contrib.auth.models"),
-                        installed_apps_hash="__hashed_installed_apps__",
-                        significant_info=["__significant__django.contrib.auth.models__"],
-                    ),
-                    all_related_models=[
-                        ImportPath("django.contrib.admin.models.LogEntry"),
-                        ImportPath("django.contrib.auth.models.AbstractUser"),
-                        ImportPath("django.contrib.auth.models.Group"),
-                        ImportPath("django.contrib.auth.models.Permission"),
-                        ImportPath("django.contrib.auth.models.PermissionsMixin"),
-                        ImportPath("django.contrib.auth.models.User"),
-                        ImportPath("django.contrib.contenttypes.models.ContentType"),
+                all_related_models=[
+                    ImportPath("django.contrib.auth.base_user.AbstractBaseUser"),
+                ],
+                concrete_models={
+                    ImportPath("django.contrib.auth.base_user.AbstractBaseUser"): [
+                        IsModel("django.contrib.auth.models.User")
                     ],
-                    concrete_models={
-                        ImportPath("django.contrib.auth.models.AbstractUser"): [
-                            IsModel("django.contrib.auth.models.User")
-                        ],
-                        ImportPath("django.contrib.auth.models.Group"): [
-                            IsModel("django.contrib.auth.models.Group")
-                        ],
-                        ImportPath("django.contrib.auth.models.Permission"): [
-                            IsModel("django.contrib.auth.models.Permission")
-                        ],
-                        ImportPath("django.contrib.auth.models.PermissionsMixin"): [
-                            IsModel("django.contrib.auth.models.User")
-                        ],
-                        ImportPath("django.contrib.auth.models.User"): [
-                            IsModel("django.contrib.auth.models.User")
-                        ],
-                    },
+                },
+            ),
+            ImportPath("django.contrib.auth.models"): CustomVirtualDependency(
+                module=IsModule("django.contrib.auth.models"),
+                interface_differentiator="__differentiated__",
+                summary=virtual_dependencies.VirtualDependencySummary(
+                    virtual_dependency_name=ImportPath("__virtual__.mod_2289830437"),
+                    module_import_path=ImportPath("django.contrib.auth.models"),
+                    installed_apps_hash="__hashed_installed_apps__",
+                    significant_info=["__significant__django.contrib.auth.models__"],
                 ),
-                ImportPath("django.contrib.contenttypes.models"): CustomVirtualDependency(
-                    module=IsModule("django.contrib.contenttypes.models"),
-                    interface_differentiator="__differentiated__",
-                    summary=virtual_dependencies.VirtualDependencySummary(
-                        virtual_dependency_name=ImportPath("__virtual__.mod_3961720227"),
-                        module_import_path=ImportPath("django.contrib.contenttypes.models"),
-                        installed_apps_hash="__hashed_installed_apps__",
-                        significant_info=["__significant__django.contrib.contenttypes.models__"],
-                    ),
-                    all_related_models=[
-                        ImportPath("django.contrib.admin.models.LogEntry"),
-                        ImportPath("django.contrib.auth.models.Permission"),
-                        ImportPath("django.contrib.contenttypes.models.ContentType"),
+                all_related_models=[
+                    ImportPath("django.contrib.admin.models.LogEntry"),
+                    ImportPath("django.contrib.auth.models.AbstractUser"),
+                    ImportPath("django.contrib.auth.models.Group"),
+                    ImportPath("django.contrib.auth.models.Permission"),
+                    ImportPath("django.contrib.auth.models.PermissionsMixin"),
+                    ImportPath("django.contrib.auth.models.User"),
+                    ImportPath("django.contrib.contenttypes.models.ContentType"),
+                ],
+                concrete_models={
+                    ImportPath("django.contrib.auth.models.AbstractUser"): [
+                        IsModel("django.contrib.auth.models.User")
                     ],
-                    concrete_models={
-                        ImportPath("django.contrib.contenttypes.models.ContentType"): [
-                            IsModel("django.contrib.contenttypes.models.ContentType")
-                        ]
-                    },
-                ),
-                ImportPath("django.contrib.sessions.base_session"): CustomVirtualDependency(
-                    module=IsModule("django.contrib.sessions.base_session"),
-                    interface_differentiator="__differentiated__",
-                    summary=virtual_dependencies.VirtualDependencySummary(
-                        virtual_dependency_name=ImportPath("__virtual__.mod_113708644"),
-                        module_import_path=ImportPath("django.contrib.sessions.base_session"),
-                        installed_apps_hash="__hashed_installed_apps__",
-                        significant_info=["__significant__django.contrib.sessions.base_session__"],
-                    ),
-                    all_related_models=[
-                        ImportPath("django.contrib.sessions.base_session.AbstractBaseSession"),
+                    ImportPath("django.contrib.auth.models.Group"): [
+                        IsModel("django.contrib.auth.models.Group")
                     ],
-                    concrete_models={
-                        ImportPath("django.contrib.sessions.base_session.AbstractBaseSession"): [
-                            IsModel("django.contrib.sessions.models.Session")
-                        ]
-                    },
-                ),
-                ImportPath("django.contrib.sessions.models"): CustomVirtualDependency(
-                    module=IsModule("django.contrib.sessions.models"),
-                    interface_differentiator="__differentiated__",
-                    summary=virtual_dependencies.VirtualDependencySummary(
-                        virtual_dependency_name=ImportPath("__virtual__.mod_3074165738"),
-                        module_import_path=ImportPath("django.contrib.sessions.models"),
-                        installed_apps_hash="__hashed_installed_apps__",
-                        significant_info=["__significant__django.contrib.sessions.models__"],
-                    ),
-                    all_related_models=[
-                        ImportPath("django.contrib.sessions.models.Session"),
+                    ImportPath("django.contrib.auth.models.Permission"): [
+                        IsModel("django.contrib.auth.models.Permission")
                     ],
-                    concrete_models={
-                        ImportPath("django.contrib.sessions.models.Session"): [
-                            IsModel("django.contrib.sessions.models.Session")
-                        ],
-                    },
-                ),
-                ImportPath("djangoexample.exampleapp.models"): CustomVirtualDependency(
-                    module=IsModule("djangoexample.exampleapp.models"),
-                    interface_differentiator="__differentiated__",
-                    summary=virtual_dependencies.VirtualDependencySummary(
-                        virtual_dependency_name=ImportPath("__virtual__.mod_3347844205"),
-                        module_import_path=ImportPath("djangoexample.exampleapp.models"),
-                        installed_apps_hash="__hashed_installed_apps__",
-                        significant_info=["__significant__djangoexample.exampleapp.models__"],
-                    ),
-                    all_related_models=[
-                        ImportPath("djangoexample.exampleapp.models.Child1"),
-                        ImportPath("djangoexample.exampleapp.models.Child2"),
-                        ImportPath("djangoexample.exampleapp.models.Child3"),
-                        ImportPath("djangoexample.exampleapp.models.Child4"),
-                        ImportPath("djangoexample.exampleapp.models.Parent"),
-                        ImportPath("djangoexample.exampleapp.models.Parent2"),
+                    ImportPath("django.contrib.auth.models.PermissionsMixin"): [
+                        IsModel("django.contrib.auth.models.User")
                     ],
-                    concrete_models={
-                        ImportPath("djangoexample.exampleapp.models.Child1"): [
-                            IsModel("djangoexample.exampleapp.models.Child1"),
-                        ],
-                        ImportPath("djangoexample.exampleapp.models.Child2"): [
-                            IsModel("djangoexample.exampleapp.models.Child2")
-                        ],
-                        ImportPath("djangoexample.exampleapp.models.Child3"): [
-                            IsModel("djangoexample.exampleapp.models.Child3")
-                        ],
-                        ImportPath("djangoexample.exampleapp.models.Child4"): [
-                            IsModel("djangoexample.exampleapp.models.Child4")
-                        ],
-                        ImportPath("djangoexample.exampleapp.models.Parent"): [
-                            IsModel("djangoexample.exampleapp.models.Child1"),
-                            IsModel("djangoexample.exampleapp.models.Child2"),
-                            IsModel("djangoexample.exampleapp.models.Child3"),
-                            IsModel("djangoexample.exampleapp.models.Child4"),
-                            IsModel("djangoexample.exampleapp2.models.ChildOther"),
-                            IsModel("djangoexample.exampleapp2.models.ChildOther2"),
-                        ],
-                        ImportPath("djangoexample.exampleapp.models.Parent2"): [
-                            IsModel("djangoexample.exampleapp.models.Child3"),
-                            IsModel("djangoexample.exampleapp.models.Child4"),
-                        ],
-                    },
-                ),
-                ImportPath("djangoexample.exampleapp2.models"): CustomVirtualDependency(
-                    module=IsModule("djangoexample.exampleapp2.models"),
-                    interface_differentiator="__differentiated__",
-                    summary=virtual_dependencies.VirtualDependencySummary(
-                        virtual_dependency_name=ImportPath("__virtual__.mod_3537308831"),
-                        module_import_path=ImportPath("djangoexample.exampleapp2.models"),
-                        installed_apps_hash="__hashed_installed_apps__",
-                        significant_info=["__significant__djangoexample.exampleapp2.models__"],
-                    ),
-                    all_related_models=[
-                        ImportPath("djangoexample.exampleapp2.models.ChildOther"),
-                        ImportPath("djangoexample.exampleapp2.models.ChildOther2"),
+                    ImportPath("django.contrib.auth.models.User"): [
+                        IsModel("django.contrib.auth.models.User")
                     ],
-                    concrete_models={
-                        ImportPath("djangoexample.exampleapp2.models.ChildOther"): [
-                            IsModel("djangoexample.exampleapp2.models.ChildOther")
-                        ],
-                        ImportPath("djangoexample.exampleapp2.models.ChildOther2"): [
-                            IsModel("djangoexample.exampleapp2.models.ChildOther2"),
-                        ],
-                    },
+                },
+            ),
+            ImportPath("django.contrib.contenttypes.models"): CustomVirtualDependency(
+                module=IsModule("django.contrib.contenttypes.models"),
+                interface_differentiator="__differentiated__",
+                summary=virtual_dependencies.VirtualDependencySummary(
+                    virtual_dependency_name=ImportPath("__virtual__.mod_3961720227"),
+                    module_import_path=ImportPath("django.contrib.contenttypes.models"),
+                    installed_apps_hash="__hashed_installed_apps__",
+                    significant_info=["__significant__django.contrib.contenttypes.models__"],
                 ),
-                ImportPath("djangoexample.only_abstract.models"): CustomVirtualDependency(
-                    module=IsModule("djangoexample.only_abstract.models"),
-                    interface_differentiator="__differentiated__",
-                    summary=virtual_dependencies.VirtualDependencySummary(
-                        virtual_dependency_name=ImportPath("__virtual__.mod_4035906997"),
-                        module_import_path=ImportPath("djangoexample.only_abstract.models"),
-                        installed_apps_hash="__hashed_installed_apps__",
-                        significant_info=["__significant__djangoexample.only_abstract.models__"],
-                    ),
-                    all_related_models=[
-                        ImportPath("djangoexample.only_abstract.models.AnAbstract"),
+                all_related_models=[
+                    ImportPath("django.contrib.admin.models.LogEntry"),
+                    ImportPath("django.contrib.auth.models.Permission"),
+                    ImportPath("django.contrib.contenttypes.models.ContentType"),
+                ],
+                concrete_models={
+                    ImportPath("django.contrib.contenttypes.models.ContentType"): [
+                        IsModel("django.contrib.contenttypes.models.ContentType")
+                    ]
+                },
+            ),
+            ImportPath("django.contrib.sessions.base_session"): CustomVirtualDependency(
+                module=IsModule("django.contrib.sessions.base_session"),
+                interface_differentiator="__differentiated__",
+                summary=virtual_dependencies.VirtualDependencySummary(
+                    virtual_dependency_name=ImportPath("__virtual__.mod_113708644"),
+                    module_import_path=ImportPath("django.contrib.sessions.base_session"),
+                    installed_apps_hash="__hashed_installed_apps__",
+                    significant_info=["__significant__django.contrib.sessions.base_session__"],
+                ),
+                all_related_models=[
+                    ImportPath("django.contrib.sessions.base_session.AbstractBaseSession"),
+                ],
+                concrete_models={
+                    ImportPath("django.contrib.sessions.base_session.AbstractBaseSession"): [
+                        IsModel("django.contrib.sessions.models.Session")
+                    ]
+                },
+            ),
+            ImportPath("django.contrib.sessions.models"): CustomVirtualDependency(
+                module=IsModule("django.contrib.sessions.models"),
+                interface_differentiator="__differentiated__",
+                summary=virtual_dependencies.VirtualDependencySummary(
+                    virtual_dependency_name=ImportPath("__virtual__.mod_3074165738"),
+                    module_import_path=ImportPath("django.contrib.sessions.models"),
+                    installed_apps_hash="__hashed_installed_apps__",
+                    significant_info=["__significant__django.contrib.sessions.models__"],
+                ),
+                all_related_models=[
+                    ImportPath("django.contrib.sessions.models.Session"),
+                ],
+                concrete_models={
+                    ImportPath("django.contrib.sessions.models.Session"): [
+                        IsModel("django.contrib.sessions.models.Session")
                     ],
-                    concrete_models={
-                        ImportPath("djangoexample.only_abstract.models.AnAbstract"): [],
-                    },
+                },
+            ),
+            ImportPath("djangoexample.exampleapp.models"): CustomVirtualDependency(
+                module=IsModule("djangoexample.exampleapp.models"),
+                interface_differentiator="__differentiated__",
+                summary=virtual_dependencies.VirtualDependencySummary(
+                    virtual_dependency_name=ImportPath("__virtual__.mod_3347844205"),
+                    module_import_path=ImportPath("djangoexample.exampleapp.models"),
+                    installed_apps_hash="__hashed_installed_apps__",
+                    significant_info=["__significant__djangoexample.exampleapp.models__"],
                 ),
-                ImportPath("djangoexample.relations1.models"): CustomVirtualDependency(
-                    module=IsModule("djangoexample.relations1.models"),
-                    interface_differentiator="__differentiated__",
-                    summary=virtual_dependencies.VirtualDependencySummary(
-                        virtual_dependency_name=ImportPath("__virtual__.mod_3327724610"),
-                        module_import_path=ImportPath("djangoexample.relations1.models"),
-                        installed_apps_hash="__hashed_installed_apps__",
-                        significant_info=["__significant__djangoexample.relations1.models__"],
-                    ),
-                    all_related_models=[
-                        ImportPath("djangoexample.relations1.models.Abstract"),
-                        ImportPath("djangoexample.relations1.models.Child1"),
-                        ImportPath("djangoexample.relations1.models.Child2"),
-                        ImportPath("djangoexample.relations1.models.Concrete1"),
-                        ImportPath("djangoexample.relations1.models.Concrete2"),
-                        ImportPath("djangoexample.relations2.models.Thing"),
+                all_related_models=[
+                    ImportPath("djangoexample.exampleapp.models.Child1"),
+                    ImportPath("djangoexample.exampleapp.models.Child2"),
+                    ImportPath("djangoexample.exampleapp.models.Child3"),
+                    ImportPath("djangoexample.exampleapp.models.Child4"),
+                    ImportPath("djangoexample.exampleapp.models.Parent"),
+                    ImportPath("djangoexample.exampleapp.models.Parent2"),
+                ],
+                concrete_models={
+                    ImportPath("djangoexample.exampleapp.models.Child1"): [
+                        IsModel("djangoexample.exampleapp.models.Child1"),
                     ],
-                    concrete_models={
-                        ImportPath("djangoexample.relations1.models.Abstract"): [
-                            IsModel("djangoexample.relations1.models.Child1"),
-                            IsModel("djangoexample.relations1.models.Child2"),
-                        ],
-                        ImportPath("djangoexample.relations1.models.Child1"): [
-                            IsModel("djangoexample.relations1.models.Child1"),
-                        ],
-                        ImportPath("djangoexample.relations1.models.Child2"): [
-                            IsModel("djangoexample.relations1.models.Child2"),
-                        ],
-                        ImportPath("djangoexample.relations1.models.Concrete1"): [
-                            IsModel("djangoexample.relations1.models.Concrete1"),
-                        ],
-                        ImportPath("djangoexample.relations1.models.Concrete2"): [
-                            IsModel("djangoexample.relations1.models.Concrete2"),
-                        ],
-                    },
-                ),
-                ImportPath("djangoexample.relations2.models"): CustomVirtualDependency(
-                    module=IsModule("djangoexample.relations2.models"),
-                    interface_differentiator="__differentiated__",
-                    summary=virtual_dependencies.VirtualDependencySummary(
-                        virtual_dependency_name=ImportPath("__virtual__.mod_3328248899"),
-                        module_import_path=ImportPath("djangoexample.relations2.models"),
-                        installed_apps_hash="__hashed_installed_apps__",
-                        significant_info=["__significant__djangoexample.relations2.models__"],
-                    ),
-                    all_related_models=[
-                        ImportPath("djangoexample.relations1.models.Concrete1"),
-                        ImportPath("djangoexample.relations2.models.Thing"),
+                    ImportPath("djangoexample.exampleapp.models.Child2"): [
+                        IsModel("djangoexample.exampleapp.models.Child2")
                     ],
-                    concrete_models={
-                        ImportPath("djangoexample.relations2.models.Thing"): [
-                            IsModel("djangoexample.relations2.models.Thing")
-                        ],
-                    },
+                    ImportPath("djangoexample.exampleapp.models.Child3"): [
+                        IsModel("djangoexample.exampleapp.models.Child3")
+                    ],
+                    ImportPath("djangoexample.exampleapp.models.Child4"): [
+                        IsModel("djangoexample.exampleapp.models.Child4")
+                    ],
+                    ImportPath("djangoexample.exampleapp.models.Parent"): [
+                        IsModel("djangoexample.exampleapp.models.Child1"),
+                        IsModel("djangoexample.exampleapp.models.Child2"),
+                        IsModel("djangoexample.exampleapp.models.Child3"),
+                        IsModel("djangoexample.exampleapp.models.Child4"),
+                        IsModel("djangoexample.exampleapp2.models.ChildOther"),
+                        IsModel("djangoexample.exampleapp2.models.ChildOther2"),
+                    ],
+                    ImportPath("djangoexample.exampleapp.models.Parent2"): [
+                        IsModel("djangoexample.exampleapp.models.Child3"),
+                        IsModel("djangoexample.exampleapp.models.Child4"),
+                    ],
+                },
+            ),
+            ImportPath("djangoexample.exampleapp2.models"): CustomVirtualDependency(
+                module=IsModule("djangoexample.exampleapp2.models"),
+                interface_differentiator="__differentiated__",
+                summary=virtual_dependencies.VirtualDependencySummary(
+                    virtual_dependency_name=ImportPath("__virtual__.mod_3537308831"),
+                    module_import_path=ImportPath("djangoexample.exampleapp2.models"),
+                    installed_apps_hash="__hashed_installed_apps__",
+                    significant_info=["__significant__djangoexample.exampleapp2.models__"],
                 ),
-            },
-        )
+                all_related_models=[
+                    ImportPath("djangoexample.exampleapp2.models.ChildOther"),
+                    ImportPath("djangoexample.exampleapp2.models.ChildOther2"),
+                ],
+                concrete_models={
+                    ImportPath("djangoexample.exampleapp2.models.ChildOther"): [
+                        IsModel("djangoexample.exampleapp2.models.ChildOther")
+                    ],
+                    ImportPath("djangoexample.exampleapp2.models.ChildOther2"): [
+                        IsModel("djangoexample.exampleapp2.models.ChildOther2"),
+                    ],
+                },
+            ),
+            ImportPath("djangoexample.only_abstract.models"): CustomVirtualDependency(
+                module=IsModule("djangoexample.only_abstract.models"),
+                interface_differentiator="__differentiated__",
+                summary=virtual_dependencies.VirtualDependencySummary(
+                    virtual_dependency_name=ImportPath("__virtual__.mod_4035906997"),
+                    module_import_path=ImportPath("djangoexample.only_abstract.models"),
+                    installed_apps_hash="__hashed_installed_apps__",
+                    significant_info=["__significant__djangoexample.only_abstract.models__"],
+                ),
+                all_related_models=[
+                    ImportPath("djangoexample.only_abstract.models.AnAbstract"),
+                ],
+                concrete_models={
+                    ImportPath("djangoexample.only_abstract.models.AnAbstract"): [],
+                },
+            ),
+            ImportPath("djangoexample.relations1.models"): CustomVirtualDependency(
+                module=IsModule("djangoexample.relations1.models"),
+                interface_differentiator="__differentiated__",
+                summary=virtual_dependencies.VirtualDependencySummary(
+                    virtual_dependency_name=ImportPath("__virtual__.mod_3327724610"),
+                    module_import_path=ImportPath("djangoexample.relations1.models"),
+                    installed_apps_hash="__hashed_installed_apps__",
+                    significant_info=["__significant__djangoexample.relations1.models__"],
+                ),
+                all_related_models=[
+                    ImportPath("djangoexample.relations1.models.Abstract"),
+                    ImportPath("djangoexample.relations1.models.Child1"),
+                    ImportPath("djangoexample.relations1.models.Child2"),
+                    ImportPath("djangoexample.relations1.models.Concrete1"),
+                    ImportPath("djangoexample.relations1.models.Concrete2"),
+                    ImportPath("djangoexample.relations2.models.Thing"),
+                ],
+                concrete_models={
+                    ImportPath("djangoexample.relations1.models.Abstract"): [
+                        IsModel("djangoexample.relations1.models.Child1"),
+                        IsModel("djangoexample.relations1.models.Child2"),
+                    ],
+                    ImportPath("djangoexample.relations1.models.Child1"): [
+                        IsModel("djangoexample.relations1.models.Child1"),
+                    ],
+                    ImportPath("djangoexample.relations1.models.Child2"): [
+                        IsModel("djangoexample.relations1.models.Child2"),
+                    ],
+                    ImportPath("djangoexample.relations1.models.Concrete1"): [
+                        IsModel("djangoexample.relations1.models.Concrete1"),
+                    ],
+                    ImportPath("djangoexample.relations1.models.Concrete2"): [
+                        IsModel("djangoexample.relations1.models.Concrete2"),
+                    ],
+                },
+            ),
+            ImportPath("djangoexample.relations2.models"): CustomVirtualDependency(
+                module=IsModule("djangoexample.relations2.models"),
+                interface_differentiator="__differentiated__",
+                summary=virtual_dependencies.VirtualDependencySummary(
+                    virtual_dependency_name=ImportPath("__virtual__.mod_3328248899"),
+                    module_import_path=ImportPath("djangoexample.relations2.models"),
+                    installed_apps_hash="__hashed_installed_apps__",
+                    significant_info=["__significant__djangoexample.relations2.models__"],
+                ),
+                all_related_models=[
+                    ImportPath("djangoexample.relations1.models.Concrete1"),
+                    ImportPath("djangoexample.relations2.models.Thing"),
+                ],
+                concrete_models={
+                    ImportPath("djangoexample.relations2.models.Thing"): [
+                        IsModel("djangoexample.relations2.models.Thing")
+                    ],
+                },
+            ),
+        }

--- a/tests/django_analysis/virtual_dependencies/test_report.py
+++ b/tests/django_analysis/virtual_dependencies/test_report.py
@@ -1,4 +1,12 @@
-from extended_mypy_django_plugin.django_analysis import ImportPath, virtual_dependencies
+import dataclasses
+
+from extended_mypy_django_plugin.django_analysis import (
+    Field,
+    ImportPath,
+    Model,
+    protocols,
+    virtual_dependencies,
+)
 
 
 class TestCombiningReports:
@@ -82,5 +90,351 @@ class TestCombiningReports:
                 ImportPath("M1"): {ImportPath("VM1"), ImportPath("VM2")},
                 ImportPath("M2"): {ImportPath("VM1"), ImportPath("VM2")},
                 ImportPath("M3"): {ImportPath("VM3")},
+            },
+        )
+
+
+class TestBuildingReport:
+    def test_registering_module_edits_report_import_path(self) -> None:
+        report = virtual_dependencies.Report()
+        report.register_module(
+            module_import_path=ImportPath("one.two"),
+            virtual_import_path=ImportPath("virtual.one.two"),
+        )
+        assert report == virtual_dependencies.Report(
+            report_import_path={
+                ImportPath("one.two"): ImportPath("virtual.one.two"),
+            }
+        )
+
+        report.register_module(
+            module_import_path=ImportPath("three.four"),
+            virtual_import_path=ImportPath("virtual.three.four"),
+        )
+        assert report == virtual_dependencies.Report(
+            report_import_path={
+                ImportPath("one.two"): ImportPath("virtual.one.two"),
+                ImportPath("three.four"): ImportPath("virtual.three.four"),
+            }
+        )
+
+    @dataclasses.dataclass
+    class BuildingScenario:
+        parent: protocols.Model = dataclasses.field(
+            default_factory=lambda: Model(
+                model_name="Parent",
+                module_import_path=ImportPath("my.parents"),
+                import_path=ImportPath("my.parents.Parent"),
+                is_abstract=True,
+                default_custom_queryset=None,
+                all_fields={},
+                models_in_mro=[],
+            )
+        )
+
+        def register_parent(self, report: virtual_dependencies.Report) -> None:
+            report.register_model(
+                model_import_path=self.parent.import_path,
+                virtual_import_path=ImportPath(f"virtual.{self.parent.module_import_path}"),
+                concrete_name="Concrete__Parent",
+                concrete_queryset_name="Queryset__Parent",
+                concrete_models=[self.model1, self.model2],
+            )
+
+        model1: protocols.Model = dataclasses.field(
+            default_factory=lambda: Model(
+                model_name="Model1",
+                module_import_path=ImportPath("my.models"),
+                import_path=ImportPath("my.models.Model1"),
+                is_abstract=False,
+                default_custom_queryset=ImportPath("my.querysets.Model1QS"),
+                all_fields={},
+                models_in_mro=[ImportPath("my.parents.Parent")],
+            )
+        )
+
+        def register_model1(self, report: virtual_dependencies.Report) -> None:
+            report.register_model(
+                model_import_path=self.model1.import_path,
+                virtual_import_path=ImportPath(f"virtual.{self.model1.module_import_path}"),
+                concrete_name="Concrete__Model1",
+                concrete_queryset_name="Queryset__Model1",
+                concrete_models=[self.model1],
+            )
+
+        model2: protocols.Model = dataclasses.field(
+            default_factory=lambda: Model(
+                model_name="Model2",
+                module_import_path=ImportPath("my.models"),
+                import_path=ImportPath("my.models.Model2"),
+                is_abstract=False,
+                default_custom_queryset=None,
+                all_fields={
+                    "one": Field(
+                        model_import_path=ImportPath("my.models.Model2"),
+                        field_type=ImportPath("fields.Foreign"),
+                        related_model=ImportPath("my.models.Model1"),
+                    ),
+                    "two": Field(
+                        model_import_path=ImportPath("my.models.Model2"),
+                        field_type=ImportPath("fields.Foreign"),
+                        related_model=ImportPath("other.models.Model3"),
+                    ),
+                },
+                models_in_mro=[ImportPath("my.parents.Parent")],
+            )
+        )
+
+        def register_model2(self, report: virtual_dependencies.Report) -> None:
+            report.register_model(
+                model_import_path=self.model2.import_path,
+                virtual_import_path=ImportPath(f"virtual.{self.model2.module_import_path}"),
+                concrete_name="Concrete__Model2",
+                concrete_queryset_name="Queryset__Model2",
+                concrete_models=[self.model2],
+            )
+
+        model3: protocols.Model = dataclasses.field(
+            default_factory=lambda: Model(
+                model_name="Model3",
+                module_import_path=ImportPath("other.models"),
+                import_path=ImportPath("other.models.Model3"),
+                is_abstract=False,
+                default_custom_queryset=ImportPath("my.querysets.Model3QS"),
+                all_fields={
+                    "three": Field(
+                        model_import_path=ImportPath("other.models.Model3"),
+                        field_type=ImportPath("fields.Foreign"),
+                        related_model=ImportPath("more.models.Model4"),
+                    ),
+                },
+                models_in_mro=[ImportPath("mixins.BlahMixin")],
+            )
+        )
+
+        def register_model3(self, report: virtual_dependencies.Report) -> None:
+            report.register_model(
+                model_import_path=self.model3.import_path,
+                virtual_import_path=ImportPath(f"virtual.{self.model3.module_import_path}"),
+                concrete_name="Concrete__Model3",
+                concrete_queryset_name="Queryset__Model3",
+                concrete_models=[self.model3],
+            )
+
+    def test_building_individually_parent(self) -> None:
+        scenario = self.BuildingScenario()
+
+        report = virtual_dependencies.Report()
+        scenario.register_parent(report)
+
+        assert report == virtual_dependencies.Report(
+            concrete_annotations={
+                ImportPath("my.parents.Parent"): ImportPath("virtual.my.parents.Concrete__Parent"),
+            },
+            concrete_querysets={
+                ImportPath("my.parents.Parent"): ImportPath("virtual.my.parents.Queryset__Parent"),
+            },
+            related_import_paths={
+                ImportPath("my.parents"): {
+                    ImportPath("my.models"),
+                    ImportPath("my.querysets"),
+                    ImportPath("other.models"),
+                },
+                ImportPath("my.models"): {ImportPath("my.parents")},
+                ImportPath("my.querysets"): {ImportPath("my.parents")},
+                ImportPath("other.models"): {ImportPath("my.parents")},
+            },
+        )
+
+    def test_building_individually_model1(self) -> None:
+        scenario = self.BuildingScenario()
+
+        report = virtual_dependencies.Report()
+        scenario.register_model1(report)
+
+        assert report == virtual_dependencies.Report(
+            concrete_annotations={
+                ImportPath("my.models.Model1"): ImportPath("virtual.my.models.Concrete__Model1"),
+            },
+            concrete_querysets={
+                ImportPath("my.models.Model1"): ImportPath("virtual.my.models.Queryset__Model1"),
+            },
+            related_import_paths={
+                ImportPath("my.parents"): {ImportPath("my.models")},
+                ImportPath("my.models"): {ImportPath("my.parents"), ImportPath("my.querysets")},
+                ImportPath("my.querysets"): {ImportPath("my.models")},
+            },
+        )
+
+    def test_building_individually_model2(self) -> None:
+        scenario = self.BuildingScenario()
+
+        report = virtual_dependencies.Report()
+        scenario.register_model2(report)
+
+        assert report == virtual_dependencies.Report(
+            concrete_annotations={
+                ImportPath("my.models.Model2"): ImportPath("virtual.my.models.Concrete__Model2"),
+            },
+            concrete_querysets={
+                ImportPath("my.models.Model2"): ImportPath("virtual.my.models.Queryset__Model2"),
+            },
+            related_import_paths={
+                ImportPath("my.parents"): {ImportPath("my.models")},
+                ImportPath("my.models"): {ImportPath("my.parents"), ImportPath("other.models")},
+                ImportPath("other.models"): {ImportPath("my.models")},
+            },
+        )
+
+    def test_building_individually_model3(self) -> None:
+        scenario = self.BuildingScenario()
+
+        report = virtual_dependencies.Report()
+        scenario.register_model3(report)
+
+        assert report == virtual_dependencies.Report(
+            concrete_annotations={
+                ImportPath("other.models.Model3"): ImportPath(
+                    "virtual.other.models.Concrete__Model3"
+                ),
+            },
+            concrete_querysets={
+                ImportPath("other.models.Model3"): ImportPath(
+                    "virtual.other.models.Queryset__Model3"
+                ),
+            },
+            related_import_paths={
+                ImportPath("mixins"): {ImportPath("other.models")},
+                ImportPath("more.models"): {ImportPath("other.models")},
+                ImportPath("my.querysets"): {ImportPath("other.models")},
+                ImportPath("other.models"): {
+                    ImportPath("mixins"),
+                    ImportPath("more.models"),
+                    ImportPath("my.querysets"),
+                },
+            },
+        )
+
+    def test_building_up_a_report(self) -> None:
+        scenario = self.BuildingScenario()
+
+        report = virtual_dependencies.Report()
+        scenario.register_parent(report)
+
+        assert report == virtual_dependencies.Report(
+            concrete_annotations={
+                ImportPath("my.parents.Parent"): ImportPath("virtual.my.parents.Concrete__Parent"),
+            },
+            concrete_querysets={
+                ImportPath("my.parents.Parent"): ImportPath("virtual.my.parents.Queryset__Parent"),
+            },
+            related_import_paths={
+                ImportPath("my.parents"): {
+                    ImportPath("my.models"),
+                    ImportPath("my.querysets"),
+                    ImportPath("other.models"),
+                },
+                ImportPath("my.models"): {ImportPath("my.parents")},
+                ImportPath("my.querysets"): {ImportPath("my.parents")},
+                ImportPath("other.models"): {ImportPath("my.parents")},
+            },
+        )
+
+        scenario.register_model1(report)
+
+        assert report == virtual_dependencies.Report(
+            concrete_annotations={
+                ImportPath("my.parents.Parent"): ImportPath("virtual.my.parents.Concrete__Parent"),
+                ImportPath("my.models.Model1"): ImportPath("virtual.my.models.Concrete__Model1"),
+            },
+            concrete_querysets={
+                ImportPath("my.parents.Parent"): ImportPath("virtual.my.parents.Queryset__Parent"),
+                ImportPath("my.models.Model1"): ImportPath("virtual.my.models.Queryset__Model1"),
+            },
+            related_import_paths={
+                ImportPath("my.parents"): {
+                    ImportPath("my.models"),
+                    ImportPath("my.querysets"),
+                    ImportPath("other.models"),
+                },
+                ImportPath("my.models"): {ImportPath("my.parents"), ImportPath("my.querysets")},
+                ImportPath("my.querysets"): {ImportPath("my.parents"), ImportPath("my.models")},
+                ImportPath("other.models"): {ImportPath("my.parents")},
+            },
+        )
+
+        scenario.register_model2(report)
+
+        assert report == virtual_dependencies.Report(
+            concrete_annotations={
+                ImportPath("my.parents.Parent"): ImportPath("virtual.my.parents.Concrete__Parent"),
+                ImportPath("my.models.Model1"): ImportPath("virtual.my.models.Concrete__Model1"),
+                ImportPath("my.models.Model2"): ImportPath("virtual.my.models.Concrete__Model2"),
+            },
+            concrete_querysets={
+                ImportPath("my.parents.Parent"): ImportPath("virtual.my.parents.Queryset__Parent"),
+                ImportPath("my.models.Model1"): ImportPath("virtual.my.models.Queryset__Model1"),
+                ImportPath("my.models.Model2"): ImportPath("virtual.my.models.Queryset__Model2"),
+            },
+            related_import_paths={
+                ImportPath("my.parents"): {
+                    ImportPath("my.models"),
+                    ImportPath("my.querysets"),
+                    ImportPath("other.models"),
+                },
+                ImportPath("my.models"): {
+                    ImportPath("my.parents"),
+                    ImportPath("my.querysets"),
+                    ImportPath("other.models"),
+                },
+                ImportPath("my.querysets"): {ImportPath("my.parents"), ImportPath("my.models")},
+                ImportPath("other.models"): {ImportPath("my.models"), ImportPath("my.parents")},
+            },
+        )
+
+        scenario.register_model3(report)
+
+        assert report == virtual_dependencies.Report(
+            concrete_annotations={
+                ImportPath("my.parents.Parent"): ImportPath("virtual.my.parents.Concrete__Parent"),
+                ImportPath("my.models.Model1"): ImportPath("virtual.my.models.Concrete__Model1"),
+                ImportPath("my.models.Model2"): ImportPath("virtual.my.models.Concrete__Model2"),
+                ImportPath("other.models.Model3"): ImportPath(
+                    "virtual.other.models.Concrete__Model3"
+                ),
+            },
+            concrete_querysets={
+                ImportPath("my.parents.Parent"): ImportPath("virtual.my.parents.Queryset__Parent"),
+                ImportPath("my.models.Model1"): ImportPath("virtual.my.models.Queryset__Model1"),
+                ImportPath("my.models.Model2"): ImportPath("virtual.my.models.Queryset__Model2"),
+                ImportPath("other.models.Model3"): ImportPath(
+                    "virtual.other.models.Queryset__Model3"
+                ),
+            },
+            related_import_paths={
+                ImportPath("my.parents"): {
+                    ImportPath("my.models"),
+                    ImportPath("my.querysets"),
+                    ImportPath("other.models"),
+                },
+                ImportPath("my.models"): {
+                    ImportPath("my.parents"),
+                    ImportPath("my.querysets"),
+                    ImportPath("other.models"),
+                },
+                ImportPath("my.querysets"): {
+                    ImportPath("my.parents"),
+                    ImportPath("my.models"),
+                    ImportPath("other.models"),
+                },
+                ImportPath("more.models"): {ImportPath("other.models")},
+                ImportPath("other.models"): {
+                    ImportPath("my.models"),
+                    ImportPath("mixins"),
+                    ImportPath("more.models"),
+                    ImportPath("my.parents"),
+                    ImportPath("my.querysets"),
+                },
+                ImportPath("mixins"): {ImportPath("other.models")},
             },
         )

--- a/tests/django_analysis/virtual_dependencies/test_report.py
+++ b/tests/django_analysis/virtual_dependencies/test_report.py
@@ -15,8 +15,8 @@ class TestCombiningReports:
             report_import_path={
                 ImportPath("M1"): ImportPath("VM1"),
             },
-            related_report_import_paths={
-                ImportPath("M1"): [ImportPath("VM1"), ImportPath("VM2")],
+            related_import_paths={
+                ImportPath("M1"): {ImportPath("VM1"), ImportPath("VM2")},
             },
         )
         report2 = virtual_dependencies.Report(
@@ -29,8 +29,8 @@ class TestCombiningReports:
             report_import_path={
                 ImportPath("M2"): ImportPath("VM2"),
             },
-            related_report_import_paths={
-                ImportPath("M2"): [ImportPath("VM1"), ImportPath("VM2")],
+            related_import_paths={
+                ImportPath("M2"): {ImportPath("VM1"), ImportPath("VM2")},
             },
         )
         report3 = virtual_dependencies.Report(
@@ -47,8 +47,8 @@ class TestCombiningReports:
             report_import_path={
                 ImportPath("M3"): ImportPath("VM3"),
             },
-            related_report_import_paths={
-                ImportPath("M3"): [ImportPath("VM3")],
+            related_import_paths={
+                ImportPath("M3"): {ImportPath("VM3")},
             },
         )
 
@@ -78,9 +78,9 @@ class TestCombiningReports:
                 ImportPath("M2"): ImportPath("VM2"),
                 ImportPath("M3"): ImportPath("VM3"),
             },
-            related_report_import_paths={
-                ImportPath("M1"): [ImportPath("VM1"), ImportPath("VM2")],
-                ImportPath("M2"): [ImportPath("VM1"), ImportPath("VM2")],
-                ImportPath("M3"): [ImportPath("VM3")],
+            related_import_paths={
+                ImportPath("M1"): {ImportPath("VM1"), ImportPath("VM2")},
+                ImportPath("M2"): {ImportPath("VM1"), ImportPath("VM2")},
+                ImportPath("M3"): {ImportPath("VM3")},
             },
         )


### PR DESCRIPTION
This PR adds some docs and tests (and another method) for the ImportPath helper

And then does a bunch of refinement to the api that this puts forward for generating virtual dependencies and writing them to the disk.

These changes decouple knowledge of the exact report shape that this plugin requires, and removes unnecessary knowledge from some other parts of the api

I'm spending a lot of time getting the separation here to be nice, but I feel it's worth it. The protocols being difficult to work with is usually a good sign that things that shouldn't be coupled are.