### PR TITLE
Use report for additional deps

### DIFF
--- a/extended_mypy_django_plugin/django_analysis/protocols.py
+++ b/extended_mypy_django_plugin/django_analysis/protocols.py
@@ -15,8 +15,6 @@ if TYPE_CHECKING:
     from django.db.models.fields.related import ForeignObjectRel
 
 T_Project = TypeVar("T_Project", bound="P_Project")
-T_Report = TypeVar("T_Report", bound="P_Report")
-T_CO_Report = TypeVar("T_CO_Report", bound="P_Report", covariant=True)
 T_VirtualDependency = TypeVar("T_VirtualDependency", bound="P_VirtualDependency")
 T_CO_VirtualDependency = TypeVar(
     "T_CO_VirtualDependency", bound="P_VirtualDependency", covariant=True
@@ -24,6 +22,14 @@ T_CO_VirtualDependency = TypeVar(
 T_COT_VirtualDependency = TypeVar(
     "T_COT_VirtualDependency", bound="P_VirtualDependency", contravariant=True
 )
+
+# The difference between Report and ReportUse is that the Report has an api used to build the report
+# And ReportUse has no defined api to begin with, and is up to the thing using the report to define
+# The api it wants. For this plugin that is defined in extended_mypy_django_plugin._virtual_dependencies
+T_Report = TypeVar("T_Report", bound="P_Report")
+T_CO_Report = TypeVar("T_CO_Report", bound="P_Report", covariant=True)
+T_CO_ReportUse = TypeVar("T_CO_ReportUse", covariant=True)
+
 
 ImportPath = NewType("ImportPath", str)
 FieldsMap = Mapping[str, "Field"]
@@ -471,7 +477,7 @@ class Report(Protocol):
         """
 
 
-class CombinedReport(Protocol[T_CO_Report]):
+class CombinedReport(Protocol[T_CO_ReportUse]):
     @property
     def version(self) -> str:
         """
@@ -480,7 +486,7 @@ class CombinedReport(Protocol[T_CO_Report]):
         """
 
     @property
-    def report(self) -> T_CO_Report:
+    def report(self) -> T_CO_ReportUse:
         """
         The final combined report
         """
@@ -624,7 +630,7 @@ class ReportFactory(Protocol[T_COT_VirtualDependency, T_Report]):
         """
 
 
-class VirtualDependencyHandler(Protocol[T_CO_Report]):
+class VirtualDependencyHandler(Protocol[T_CO_ReportUse]):
     """
     This is the interface required by the mypy plugin to create virtual dependencies and get a report
     of the information held by those virtual dependencies
@@ -636,7 +642,7 @@ class VirtualDependencyHandler(Protocol[T_CO_Report]):
         project_root: pathlib.Path,
         django_settings_module: str,
         virtual_deps_destination: pathlib.Path,
-    ) -> CombinedReport[T_CO_Report]: ...
+    ) -> CombinedReport[T_CO_ReportUse]: ...
 
 
 if TYPE_CHECKING:

--- a/extended_mypy_django_plugin/django_analysis/virtual_dependencies/handler.py
+++ b/extended_mypy_django_plugin/django_analysis/virtual_dependencies/handler.py
@@ -64,7 +64,9 @@ class VirtualDependencyHandler(
             f"installed_apps:{installed_apps_hash}|settings_types:{settings_types_hash}"
         )
         virtual_dependency_installer = self.make_virtual_dependency_installer(
-            project_version=project_version, all_virtual_dependencies=all_virtual_dependencies
+            virtual_dependency_namer=virtual_dependency_namer,
+            project_version=project_version,
+            all_virtual_dependencies=all_virtual_dependencies,
         )
 
         with tempfile.TemporaryDirectory() as scratch_root:
@@ -99,10 +101,13 @@ class VirtualDependencyHandler(
         self,
         *,
         project_version: str,
+        virtual_dependency_namer: protocols.VirtualDependencyNamer,
         all_virtual_dependencies: protocols.VirtualDependencyMap[protocols.T_VirtualDependency],
     ) -> protocols.VirtualDependencyInstaller[protocols.T_VirtualDependency, protocols.T_Report]:
         return VirtualDependencyInstaller(
-            project_version=project_version, virtual_dependencies=all_virtual_dependencies
+            virtual_dependency_namer=virtual_dependency_namer,
+            project_version=project_version,
+            virtual_dependencies=all_virtual_dependencies,
         )
 
     @classmethod

--- a/extended_mypy_django_plugin/django_analysis/virtual_dependencies/report.py
+++ b/extended_mypy_django_plugin/django_analysis/virtual_dependencies/report.py
@@ -31,6 +31,10 @@ class CombinedReport(Generic[protocols.T_Report]):
     write_empty_virtual_dep: protocols.EmptyVirtualDepWriter
 
     def ensure_virtual_dependency(self, *, module_import_path: str) -> None:
+        if module_import_path.startswith("django."):
+            # Don't create empty virtual deps for django dependencies
+            return
+
         # This is a heuristic that should be accurate enough to catch modules that contain models
         # Though it may miss some models and it may include modules that aren't related to django models
         if ".models." not in module_import_path and not module_import_path.endswith(".models"):

--- a/extended_mypy_django_plugin/django_analysis/virtual_dependencies/report.py
+++ b/extended_mypy_django_plugin/django_analysis/virtual_dependencies/report.py
@@ -243,8 +243,12 @@ class VirtualDependencyScribe(Generic[protocols.T_VirtualDependency, protocols.T
                 concrete_models=concrete,
             )
 
+        sorted_added_imported_modules = sorted(
+            {".".join(imp.split(".")[:-1]) for imp in added_imports}
+        )
+
         extra_lines = [
-            *(f"    import {import_path}" for import_path in sorted(added_imports)),
+            *(f"    import {import_path}" for import_path in sorted_added_imported_modules),
             *(f"    {line}" for line in sorted(annotations)),
         ]
 

--- a/extended_mypy_django_plugin/plugin/__init__.py
+++ b/extended_mypy_django_plugin/plugin/__init__.py
@@ -3,15 +3,15 @@ from ._plugin import ExtendedMypyStubs
 from ._virtual_dependencies import (
     CombinedReportProtocol,
     DefaultVirtualDependencyHandler,
-    Report,
+    ReportProtocol,
     T_Report,
     VirtualDependencyHandlerProtocol,
 )
 
 __all__ = [
-    "Report",
     "T_Report",
     "ExtraOptions",
+    "ReportProtocol",
     "ExtendedMypyStubs",
     "CombinedReportProtocol",
     "DefaultVirtualDependencyHandler",

--- a/extended_mypy_django_plugin/plugin/_dependencies.py
+++ b/extended_mypy_django_plugin/plugin/_dependencies.py
@@ -1,5 +1,3 @@
-from mypy.nodes import Import, ImportBase, ImportFrom
-
 from ._reports import ModelModules, ReportNamesGetter
 
 Dep = tuple[int, str, int]
@@ -25,37 +23,3 @@ class Dependencies:
                     return True
 
         return False
-
-    def for_file(self, fullname: str, imports: list[ImportBase], super_deps: DepList) -> DepList:
-        deps = list(super_deps)
-
-        if fullname.startswith("django."):
-            return deps
-
-        for imp in imports:
-            found: set[str] = set()
-            if isinstance(imp, ImportFrom):
-                for name in imp.names:
-                    found.add(f"{imp.id}.{name[0]}")
-            elif isinstance(imp, Import):
-                for name in imp.ids:
-                    found.add(name[0])
-
-            for full in found:
-                for mod in self._model_modules:
-                    if full == fullname:
-                        continue
-
-                    if full == mod or full.startswith(f"{mod}."):
-                        new_dep = (10, mod, -1)
-                        if new_dep not in deps:
-                            deps.append(new_dep)
-                        break
-
-        for report in self._report_names_getter(fullname, {m for _, m, _ in deps}):
-            new_dep = (10, report, -1)
-
-            if new_dep not in deps:
-                deps.append(new_dep)
-
-        return deps

--- a/extended_mypy_django_plugin/plugin/_plugin.py
+++ b/extended_mypy_django_plugin/plugin/_plugin.py
@@ -220,6 +220,7 @@ class ExtendedMypyStubs(Generic[T_Report], main.NewSemanalDjangoPlugin):
             self.virtual_dependency_report.report.additional_deps(
                 file_import_path=file_import,
                 imports=full_imports,
+                django_settings_module=self.extra_options.django_settings_module,
                 super_deps=super().get_additional_deps(file),
             )
         )

--- a/extended_mypy_django_plugin/plugin/_plugin.py
+++ b/extended_mypy_django_plugin/plugin/_plugin.py
@@ -30,14 +30,14 @@ from typing_extensions import assert_never
 from . import _config, _dependencies, _hook, _known_annotations, _reports, _store, actions
 from ._virtual_dependencies import (
     CombinedReportProtocol,
-    Report,
+    ReportProtocol,
     T_Report,
     VirtualDependencyHandlerProtocol,
 )
 
 # Can't re-use the same type var in an embedded class
 # So we make another type var that we can substitute T_Report into
-T2_Report = TypeVar("T2_Report", bound=Report)
+T2_Report = TypeVar("T2_Report", bound=ReportProtocol)
 
 
 class Hook(

--- a/extended_mypy_django_plugin/plugin/_plugin.py
+++ b/extended_mypy_django_plugin/plugin/_plugin.py
@@ -195,6 +195,8 @@ class ExtendedMypyStubs(Generic[T_Report], main.NewSemanalDjangoPlugin):
         file_import = file.fullname
         full_imports: set[str] = set()
 
+        self.virtual_dependency_report.ensure_virtual_dependency(module_import_path=file.fullname)
+
         for imp in file.imports:
             if isinstance(imp, ImportFrom | ImportAll):
                 if imp.relative:

--- a/extended_mypy_django_plugin/plugin/_virtual_dependencies.py
+++ b/extended_mypy_django_plugin/plugin/_virtual_dependencies.py
@@ -19,12 +19,14 @@ class ReportProtocol(Protocol):
         file_import_path: str,
         imports: Set[str],
         super_deps: Sequence[tuple[int, str, int]],
+        django_settings_module: str,
     ) -> Sequence[tuple[int, str, int]]:
         """
         This is used to add to the result for the get_additional_deps mypy hook.
 
         It takes the import path for the file being looked at, any additional deps that have already
-        been determined for the file, and the imports the file contains as a list of full imports.
+        been determined for the file, the imports the file contains as a list of full imports,
+        and the import path of the django settings module.
 
         It must return the full set of additional deps the mypy plugin should use for this file
         """

--- a/extended_mypy_django_plugin/plugin/_virtual_dependencies.py
+++ b/extended_mypy_django_plugin/plugin/_virtual_dependencies.py
@@ -1,7 +1,7 @@
 import abc
 import functools
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Generic, TypeVar
+from typing import TYPE_CHECKING, Generic, Protocol, TypeVar
 
 from ..django_analysis import project, protocols, virtual_dependencies
 from ..django_analysis.protocols import (
@@ -11,8 +11,12 @@ from ..django_analysis.protocols import (
     VirtualDependencyHandler as VirtualDependencyHandlerProtocol,
 )
 
-Report = virtual_dependencies.Report
-T_Report = TypeVar("T_Report", bound=Report)
+
+class ReportProtocol(Protocol):
+    pass
+
+
+T_Report = TypeVar("T_Report", bound=ReportProtocol)
 
 
 class DefaultVirtualDependencyHandler(
@@ -20,14 +24,14 @@ class DefaultVirtualDependencyHandler(
     virtual_dependencies.VirtualDependencyHandler[
         protocols.T_Project,
         virtual_dependencies.VirtualDependency[protocols.T_Project],
-        Report,
+        virtual_dependencies.Report,
     ],
     abc.ABC,
 ):
     def make_report_factory(
         self,
     ) -> protocols.ReportFactory[
-        virtual_dependencies.VirtualDependency[protocols.T_Project], Report
+        virtual_dependencies.VirtualDependency[protocols.T_Project], virtual_dependencies.Report
     ]:
         return virtual_dependencies.make_report_factory(hasher=self.hasher)
 
@@ -52,15 +56,17 @@ class DefaultVirtualDependencyHandler(
 __all__ = [
     "VirtualDependencyHandlerProtocol",
     "CombinedReportProtocol",
+    "ReportProtocol",
     "DefaultVirtualDependencyHandler",
     "T_Report",
-    "Report",
 ]
 
 if TYPE_CHECKING:
     C_VirtualDependencyHandler = DefaultVirtualDependencyHandler[project.C_Project]
 
-    _DVDH: VirtualDependencyHandlerProtocol[Report] = DefaultVirtualDependencyHandler[
-        protocols.P_Project
-    ].create_report
-    _CDVDH: VirtualDependencyHandlerProtocol[Report] = C_VirtualDependencyHandler.create_report
+    _DVDH: VirtualDependencyHandlerProtocol[virtual_dependencies.Report] = (
+        DefaultVirtualDependencyHandler[protocols.P_Project].create_report
+    )
+    _CDVDH: VirtualDependencyHandlerProtocol[virtual_dependencies.Report] = (
+        C_VirtualDependencyHandler.create_report
+    )

--- a/extended_mypy_django_plugin/plugin/_virtual_dependencies.py
+++ b/extended_mypy_django_plugin/plugin/_virtual_dependencies.py
@@ -1,6 +1,6 @@
 import abc
 import functools
-from collections.abc import Callable
+from collections.abc import Callable, Sequence, Set
 from typing import TYPE_CHECKING, Generic, Protocol, TypeVar
 
 from ..django_analysis import project, protocols, virtual_dependencies
@@ -13,7 +13,21 @@ from ..django_analysis.protocols import (
 
 
 class ReportProtocol(Protocol):
-    pass
+    def additional_deps(
+        self,
+        *,
+        file_import_path: str,
+        imports: Set[str],
+        super_deps: Sequence[tuple[int, str, int]],
+    ) -> Sequence[tuple[int, str, int]]:
+        """
+        This is used to add to the result for the get_additional_deps mypy hook.
+
+        It takes the import path for the file being looked at, any additional deps that have already
+        been determined for the file, and the imports the file contains as a list of full imports.
+
+        It must return the full set of additional deps the mypy plugin should use for this file
+        """
 
 
 T_Report = TypeVar("T_Report", bound=ReportProtocol)

--- a/extended_mypy_django_plugin/scripts/determine_django_state.py
+++ b/extended_mypy_django_plugin/scripts/determine_django_state.py
@@ -8,7 +8,7 @@ import re
 import sys
 
 from extended_mypy_django_plugin.entry import PluginProvider
-from extended_mypy_django_plugin.plugin import ExtraOptions, Report
+from extended_mypy_django_plugin.plugin import ExtraOptions, ReportProtocol
 
 
 def make_parser() -> argparse.ArgumentParser:
@@ -30,7 +30,7 @@ def main(argv: list[str] | None = None) -> None:
     if (extra_options.scratch_path / "__assume_django_state_unchanged__").exists():
         sys.exit(2)
 
-    plugin_provider: PluginProvider[Report] | None = None
+    plugin_provider: PluginProvider[ReportProtocol] | None = None
 
     for plugin in args.mypy_plugin:
         found = load_plugin(plugin, args.config_file)

--- a/tests/django_analysis/virtual_dependencies/generated_reports/__virtual__/mod_113708644.py
+++ b/tests/django_analysis/virtual_dependencies/generated_reports/__virtual__/mod_113708644.py
@@ -7,8 +7,8 @@ mod = "django.contrib.sessions.base_session"
 summary = "__virtual__.mod_113708644::django.contrib.sessions.base_session::installed_apps=__installed_apps_hash__::significant=1879365353"
 
 if TYPE_CHECKING:
-    import django.contrib.sessions.base_session.AbstractBaseSession
-    import django.contrib.sessions.models.Session
-    import django.db.models.QuerySet
+    import django.contrib.sessions.base_session
+    import django.contrib.sessions.models
+    import django.db.models
     ConcreteQuerySet__AbstractBaseSession = django.db.models.QuerySet[django.contrib.sessions.models.Session]
     Concrete__AbstractBaseSession = django.contrib.sessions.models.Session

--- a/tests/django_analysis/virtual_dependencies/generated_reports/__virtual__/mod_2289830437.py
+++ b/tests/django_analysis/virtual_dependencies/generated_reports/__virtual__/mod_2289830437.py
@@ -7,12 +7,8 @@ mod = "django.contrib.auth.models"
 summary = "__virtual__.mod_2289830437::django.contrib.auth.models::installed_apps=__installed_apps_hash__::significant=1922836542"
 
 if TYPE_CHECKING:
-    import django.contrib.auth.models.AbstractUser
-    import django.contrib.auth.models.Group
-    import django.contrib.auth.models.Permission
-    import django.contrib.auth.models.PermissionsMixin
-    import django.contrib.auth.models.User
-    import django.db.models.QuerySet
+    import django.contrib.auth.models
+    import django.db.models
     ConcreteQuerySet__AbstractUser = django.db.models.QuerySet[django.contrib.auth.models.User]
     ConcreteQuerySet__Group = django.db.models.QuerySet[django.contrib.auth.models.Group]
     ConcreteQuerySet__Permission = django.db.models.QuerySet[django.contrib.auth.models.Permission]

--- a/tests/django_analysis/virtual_dependencies/generated_reports/__virtual__/mod_2456226428.py
+++ b/tests/django_analysis/virtual_dependencies/generated_reports/__virtual__/mod_2456226428.py
@@ -7,7 +7,7 @@ mod = "django.contrib.admin.models"
 summary = "__virtual__.mod_2456226428::django.contrib.admin.models::installed_apps=__installed_apps_hash__::significant=3233719984"
 
 if TYPE_CHECKING:
-    import django.contrib.admin.models.LogEntry
-    import django.db.models.QuerySet
+    import django.contrib.admin.models
+    import django.db.models
     ConcreteQuerySet__LogEntry = django.db.models.QuerySet[django.contrib.admin.models.LogEntry]
     Concrete__LogEntry = django.contrib.admin.models.LogEntry

--- a/tests/django_analysis/virtual_dependencies/generated_reports/__virtual__/mod_2833058650.py
+++ b/tests/django_analysis/virtual_dependencies/generated_reports/__virtual__/mod_2833058650.py
@@ -7,8 +7,8 @@ mod = "django.contrib.auth.base_user"
 summary = "__virtual__.mod_2833058650::django.contrib.auth.base_user::installed_apps=__installed_apps_hash__::significant=1762274777"
 
 if TYPE_CHECKING:
-    import django.contrib.auth.base_user.AbstractBaseUser
-    import django.contrib.auth.models.User
-    import django.db.models.QuerySet
+    import django.contrib.auth.base_user
+    import django.contrib.auth.models
+    import django.db.models
     ConcreteQuerySet__AbstractBaseUser = django.db.models.QuerySet[django.contrib.auth.models.User]
     Concrete__AbstractBaseUser = django.contrib.auth.models.User

--- a/tests/django_analysis/virtual_dependencies/generated_reports/__virtual__/mod_3074165738.py
+++ b/tests/django_analysis/virtual_dependencies/generated_reports/__virtual__/mod_3074165738.py
@@ -7,7 +7,7 @@ mod = "django.contrib.sessions.models"
 summary = "__virtual__.mod_3074165738::django.contrib.sessions.models::installed_apps=__installed_apps_hash__::significant=4231118930"
 
 if TYPE_CHECKING:
-    import django.contrib.sessions.models.Session
-    import django.db.models.QuerySet
+    import django.contrib.sessions.models
+    import django.db.models
     ConcreteQuerySet__Session = django.db.models.QuerySet[django.contrib.sessions.models.Session]
     Concrete__Session = django.contrib.sessions.models.Session

--- a/tests/django_analysis/virtual_dependencies/generated_reports/__virtual__/mod_3327724610.py
+++ b/tests/django_analysis/virtual_dependencies/generated_reports/__virtual__/mod_3327724610.py
@@ -7,14 +7,8 @@ mod = "djangoexample.relations1.models"
 summary = "__virtual__.mod_3327724610::djangoexample.relations1.models::installed_apps=__installed_apps_hash__::significant=448140218"
 
 if TYPE_CHECKING:
-    import django.db.models.QuerySet
-    import djangoexample.relations1.models.Abstract
-    import djangoexample.relations1.models.Child1
-    import djangoexample.relations1.models.Child1QuerySet
-    import djangoexample.relations1.models.Child2
-    import djangoexample.relations1.models.Concrete1
-    import djangoexample.relations1.models.Concrete1QuerySet
-    import djangoexample.relations1.models.Concrete2
+    import django.db.models
+    import djangoexample.relations1.models
     ConcreteQuerySet__Abstract = django.db.models.QuerySet[djangoexample.relations1.models.Child2] | djangoexample.relations1.models.Child1QuerySet
     ConcreteQuerySet__Child1 = djangoexample.relations1.models.Child1QuerySet
     ConcreteQuerySet__Child2 = django.db.models.QuerySet[djangoexample.relations1.models.Child2]

--- a/tests/django_analysis/virtual_dependencies/generated_reports/__virtual__/mod_3328248899.py
+++ b/tests/django_analysis/virtual_dependencies/generated_reports/__virtual__/mod_3328248899.py
@@ -7,7 +7,7 @@ mod = "djangoexample.relations2.models"
 summary = "__virtual__.mod_3328248899::djangoexample.relations2.models::installed_apps=__installed_apps_hash__::significant=1229019932"
 
 if TYPE_CHECKING:
-    import django.db.models.QuerySet
-    import djangoexample.relations2.models.Thing
+    import django.db.models
+    import djangoexample.relations2.models
     ConcreteQuerySet__Thing = django.db.models.QuerySet[djangoexample.relations2.models.Thing]
     Concrete__Thing = djangoexample.relations2.models.Thing

--- a/tests/django_analysis/virtual_dependencies/generated_reports/__virtual__/mod_3347844205.py
+++ b/tests/django_analysis/virtual_dependencies/generated_reports/__virtual__/mod_3347844205.py
@@ -7,17 +7,9 @@ mod = "djangoexample.exampleapp.models"
 summary = "__virtual__.mod_3347844205::djangoexample.exampleapp.models::installed_apps=__installed_apps_hash__::significant=2358377148"
 
 if TYPE_CHECKING:
-    import django.db.models.QuerySet
-    import djangoexample.exampleapp.models.Child1
-    import djangoexample.exampleapp.models.Child2
-    import djangoexample.exampleapp.models.Child2QuerySet
-    import djangoexample.exampleapp.models.Child3
-    import djangoexample.exampleapp.models.Child4
-    import djangoexample.exampleapp.models.Child4QuerySet
-    import djangoexample.exampleapp.models.Parent
-    import djangoexample.exampleapp.models.Parent2
-    import djangoexample.exampleapp2.models.ChildOther
-    import djangoexample.exampleapp2.models.ChildOther2
+    import django.db.models
+    import djangoexample.exampleapp.models
+    import djangoexample.exampleapp2.models
     ConcreteQuerySet__Child1 = django.db.models.QuerySet[djangoexample.exampleapp.models.Child1]
     ConcreteQuerySet__Child2 = djangoexample.exampleapp.models.Child2QuerySet
     ConcreteQuerySet__Child3 = django.db.models.QuerySet[djangoexample.exampleapp.models.Child3]

--- a/tests/django_analysis/virtual_dependencies/generated_reports/__virtual__/mod_3537308831.py
+++ b/tests/django_analysis/virtual_dependencies/generated_reports/__virtual__/mod_3537308831.py
@@ -7,9 +7,8 @@ mod = "djangoexample.exampleapp2.models"
 summary = "__virtual__.mod_3537308831::djangoexample.exampleapp2.models::installed_apps=__installed_apps_hash__::significant=1778215230"
 
 if TYPE_CHECKING:
-    import django.db.models.QuerySet
-    import djangoexample.exampleapp2.models.ChildOther
-    import djangoexample.exampleapp2.models.ChildOther2
+    import django.db.models
+    import djangoexample.exampleapp2.models
     ConcreteQuerySet__ChildOther = django.db.models.QuerySet[djangoexample.exampleapp2.models.ChildOther]
     ConcreteQuerySet__ChildOther2 = django.db.models.QuerySet[djangoexample.exampleapp2.models.ChildOther2]
     Concrete__ChildOther = djangoexample.exampleapp2.models.ChildOther

--- a/tests/django_analysis/virtual_dependencies/generated_reports/__virtual__/mod_3961720227.py
+++ b/tests/django_analysis/virtual_dependencies/generated_reports/__virtual__/mod_3961720227.py
@@ -7,7 +7,7 @@ mod = "django.contrib.contenttypes.models"
 summary = "__virtual__.mod_3961720227::django.contrib.contenttypes.models::installed_apps=__installed_apps_hash__::significant=2877817555"
 
 if TYPE_CHECKING:
-    import django.contrib.contenttypes.models.ContentType
-    import django.db.models.QuerySet
+    import django.contrib.contenttypes.models
+    import django.db.models
     ConcreteQuerySet__ContentType = django.db.models.QuerySet[django.contrib.contenttypes.models.ContentType]
     Concrete__ContentType = django.contrib.contenttypes.models.ContentType

--- a/tests/django_analysis/virtual_dependencies/generated_reports/__virtual__/mod_4035906997.py
+++ b/tests/django_analysis/virtual_dependencies/generated_reports/__virtual__/mod_4035906997.py
@@ -7,4 +7,4 @@ mod = "djangoexample.only_abstract.models"
 summary = "__virtual__.mod_4035906997::djangoexample.only_abstract.models::installed_apps=__installed_apps_hash__::significant=1262772787"
 
 if TYPE_CHECKING:
-    import djangoexample.only_abstract.models.AnAbstract
+    import djangoexample.only_abstract.models

--- a/tests/django_analysis/virtual_dependencies/test_report.py
+++ b/tests/django_analysis/virtual_dependencies/test_report.py
@@ -592,29 +592,38 @@ class TestBuildingReport:
         super_deps = [(10, "one.two", -1), (10, "two", -1)]
         assert (
             report.additional_deps(
-                file_import_path="django.db.models", imports=set(), super_deps=super_deps
+                file_import_path="django.db.models",
+                imports=set(),
+                super_deps=super_deps,
+                django_settings_module="my.settings",
             )
             is super_deps
         )
 
         # Expansion depends on super_deps and imports
-        assert (
-            report.additional_deps(file_import_path="some.place", imports=set(), super_deps=[])
-            == []
-        )
+        assert report.additional_deps(
+            file_import_path="some.place",
+            imports=set(),
+            super_deps=[],
+            django_settings_module="my.settings",
+        ) == [(10, "my.settings", -1)]
         assert sorted(
             report.additional_deps(
                 file_import_path="some.place",
                 imports={"eight.nine", "typing.Protocol"},
                 super_deps=[],
+                django_settings_module="my.settings",
             )
-        ) == sorted([(10, "v_eight_nine", -1), (10, "v_twelve_thirteen", -1)])
+        ) == sorted(
+            [(10, "v_eight_nine", -1), (10, "v_twelve_thirteen", -1), (10, "my.settings", -1)]
+        )
         # So imports and super_deps both expand, but super_deps remain in the output
         assert sorted(
             report.additional_deps(
                 file_import_path="some.place",
                 imports=set(),
                 super_deps=[(10, "eight.nine", -1), (10, "typing.Protocol", 13)],
+                django_settings_module="my.settings",
             )
         ) == sorted(
             [
@@ -622,6 +631,7 @@ class TestBuildingReport:
                 (10, "v_eight_nine", -1),
                 (10, "v_twelve_thirteen", -1),
                 (10, "typing.Protocol", 13),
+                (10, "my.settings", -1),
             ]
         )
 
@@ -632,6 +642,7 @@ class TestBuildingReport:
                 file_import_path="some.place",
                 imports={"one.two"},
                 super_deps=[(10, "hello.there", -1), (10, "typing.Protocol", 13)],
+                django_settings_module="my.settings",
             )
         ) == sorted(
             [
@@ -641,6 +652,7 @@ class TestBuildingReport:
                 (10, "v_three_four", -1),
                 (10, "hello.there", -1),
                 (10, "typing.Protocol", 13),
+                (10, "my.settings", -1),
             ]
         )
 
@@ -650,6 +662,7 @@ class TestBuildingReport:
                 file_import_path="another.one",
                 imports={"one.two"},
                 super_deps=[(10, "hello.there", -1), (10, "typing.Protocol", 13)],
+                django_settings_module="my.settings",
             )
         ) == sorted(
             [
@@ -661,6 +674,7 @@ class TestBuildingReport:
                 (10, "v_three_four", -1),
                 (10, "hello.there", -1),
                 (10, "typing.Protocol", 13),
+                (10, "my.settings", -1),
             ]
         )
 
@@ -670,6 +684,7 @@ class TestBuildingReport:
                 file_import_path="another.one",
                 imports={"one.two.MyModel"},
                 super_deps=[(10, "hello.there", -1), (10, "typing.Protocol", 13)],
+                django_settings_module="my.settings",
             )
         ) == sorted(
             [
@@ -681,6 +696,7 @@ class TestBuildingReport:
                 (10, "v_three_four", -1),
                 (10, "hello.there", -1),
                 (10, "typing.Protocol", 13),
+                (10, "my.settings", -1),
             ]
         )
 
@@ -690,5 +706,6 @@ class TestBuildingReport:
                 file_import_path="v_another_one",
                 imports={"one.two.MyModel"},
                 super_deps=[(10, "hello.there", -1), (10, "typing.Protocol", 13)],
+                django_settings_module="my.settings",
             )
         ) == sorted([(10, "hello.there", -1), (10, "typing.Protocol", 13)])

--- a/tests/django_analysis/virtual_dependencies/test_virtual_dependency_scribe.py
+++ b/tests/django_analysis/virtual_dependencies/test_virtual_dependency_scribe.py
@@ -199,9 +199,8 @@ class TestVirtualDependencyScribe:
             summary = "__virtual__.mod_3537308831::djangoexample.exampleapp2.models::installed_apps=__installed_apps_hash__::significant=__hashed_for_great_good__"
 
             if TYPE_CHECKING:
-                import django.db.models.QuerySet
-                import djangoexample.exampleapp2.models.ChildOther
-                import djangoexample.exampleapp2.models.ChildOther2
+                import django.db.models
+                import djangoexample.exampleapp2.models
                 ConcreteQuerySet__ChildOther = django.db.models.QuerySet[djangoexample.exampleapp2.models.ChildOther]
                 ConcreteQuerySet__ChildOther2 = django.db.models.QuerySet[djangoexample.exampleapp2.models.ChildOther2]
                 Concrete__ChildOther = djangoexample.exampleapp2.models.ChildOther
@@ -310,14 +309,8 @@ class TestVirtualDependencyScribe:
             summary = "__virtual__.mod_3327724610::djangoexample.relations1.models::installed_apps=__installed_apps_hash__::significant=__hashed_for_greater_good__"
 
             if TYPE_CHECKING:
-                import django.db.models.QuerySet
-                import djangoexample.relations1.models.Abstract
-                import djangoexample.relations1.models.Child1
-                import djangoexample.relations1.models.Child1QuerySet
-                import djangoexample.relations1.models.Child2
-                import djangoexample.relations1.models.Concrete1
-                import djangoexample.relations1.models.Concrete1QuerySet
-                import djangoexample.relations1.models.Concrete2
+                import django.db.models
+                import djangoexample.relations1.models
                 ConcreteQuerySet__Abstract = django.db.models.QuerySet[djangoexample.relations1.models.Child2] | djangoexample.relations1.models.Child1QuerySet
                 ConcreteQuerySet__Child1 = djangoexample.relations1.models.Child1QuerySet
                 ConcreteQuerySet__Child2 = django.db.models.QuerySet[djangoexample.relations1.models.Child2]


### PR DESCRIPTION
This change makes it so the django-analysis report is now used to determine what gets returned from the get_additional_deps hook.

This is the hook that lets us associate real modules with our virtual dependencies.

It fixes the templates of the virtual dependencies so that they are valid python, and makes it so that the plugin thinks about the report in terms of an api it needs rather than the api that was used to build the report