### PR TITLE
Allow resolving Concrete annotations from placeholders

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -3,6 +3,11 @@
 Changelog
 ---------
 
+.. _release-0.6.3:
+
+0.6.3 - 27 June 2024
+    * Fixed a bug with resolving Concrete annotations at the module scope
+
 .. _release-0.6.2:
 
 0.6.2 - 27 June 2024

--- a/extended_mypy_django_plugin/_plugin/protocols.py
+++ b/extended_mypy_django_plugin/_plugin/protocols.py
@@ -13,7 +13,16 @@ from mypy.plugin import (
     MethodContext,
     MethodSigContext,
 )
-from mypy.types import AnyType, Instance, ProperType, TypeType, TypeVarType, UnboundType, UnionType
+from mypy.types import (
+    AnyType,
+    Instance,
+    PlaceholderType,
+    ProperType,
+    TypeType,
+    TypeVarType,
+    UnboundType,
+    UnionType,
+)
 from mypy.types import Type as MypyType
 
 from ..django_analysis import protocols as d_protocols
@@ -137,7 +146,7 @@ class LookupAlias(Protocol):
     by that type alias
     """
 
-    def __call__(self, alias: str) -> Iterator[Instance]: ...
+    def __call__(self, alias: str) -> Iterator[Instance | PlaceholderType]: ...
 
 
 class LookupFullyQualified(Protocol):
@@ -165,7 +174,7 @@ class Resolver(Protocol):
 
     def resolve(
         self, annotation: KnownAnnotations, model_type: ProperType
-    ) -> Instance | TypeType | UnionType | AnyType | None:
+    ) -> Instance | TypeType | UnionType | AnyType | PlaceholderType | None:
         """
         Given a specific annotation and some model return the resolved
         concrete form.


### PR DESCRIPTION
This lets us use Concrete annotations in places where the types being annotated haven't been fully resolved yet