### PR TITLE
Make Concrete.cast_as_concrete handle type vars

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -3,6 +3,18 @@
 Changelog
 ---------
 
+.. _release-0.7.0:
+
+0.7.0 - TBD
+
+    * The ``Concrete.cast_as_concrete`` helper is now handled by a different mypy plugin
+      hook. This lets the helper understand type vars and it lets it handle more
+      complicated inputs.
+
+      However it means that in methods when using it to override ``self`` and ``cls``
+      that we can no longer override those variables. In these cases use a different
+      variable name as the result.
+
 .. _release-0.6.4:
 
 0.6.4 - 4 July 2024

--- a/example/djangoexample/exampleapp/models.py
+++ b/example/djangoexample/exampleapp/models.py
@@ -1,8 +1,18 @@
 from django.db import models
+from typing_extensions import Self
+
+from extended_mypy_django_plugin import Concrete
 
 
 class Parent(models.Model):
     one = models.CharField(max_length=50)
+
+    @classmethod
+    def new(cls, one: str) -> Self:
+        concrete = Concrete.cast_as_concrete(cls)
+        created = concrete.objects.create(one=one)
+        assert isinstance(created, cls)
+        return created
 
     class Meta:
         abstract = True

--- a/extended_mypy_django_plugin/_plugin/type_checker.py
+++ b/extended_mypy_django_plugin/_plugin/type_checker.py
@@ -1,3 +1,5 @@
+from typing import Final
+
 from mypy.nodes import CallExpr, Decorator, MemberExpr, MypyFile, SymbolNode, TypeInfo
 from mypy.plugin import (
     AttributeContext,
@@ -15,6 +17,7 @@ from mypy.types import (
     ProperType,
     TypeOfAny,
     TypeType,
+    TypeVarType,
     UnboundType,
     UnionType,
     get_proper_type,
@@ -22,6 +25,9 @@ from mypy.types import (
 from mypy.types import Type as MypyType
 
 from . import protocols, signature_info
+
+TYPING_SELF: Final[str] = "typing.Self"
+TYPING_EXTENSION_SELF: Final[str] = "typing_extensions.Self"
 
 
 class TypeChecking:
@@ -51,6 +57,100 @@ class TypeChecking:
             return None
 
         return info.resolve_return_type(ctx)
+
+    def modify_cast_as_concrete(self, ctx: FunctionContext | MethodContext) -> MypyType:
+        if len(ctx.arg_types) != 1:
+            ctx.api.fail("Concrete.cast_as_concrete takes only one argument", ctx.context)
+            return AnyType(TypeOfAny.from_error)
+
+        if not ctx.arg_types[0]:
+            ctx.api.fail("Mypy failed to tell us the type of the first argument", ctx.context)
+            return AnyType(TypeOfAny.from_error)
+
+        first_arg = get_proper_type(ctx.arg_types[0][0])
+        if isinstance(first_arg, AnyType):
+            ctx.api.fail("Failed to determine the type of the first argument", ctx.context)
+            return AnyType(TypeOfAny.from_error)
+
+        is_type: bool = False
+        if isinstance(first_arg, TypeType):
+            is_type = True
+            first_arg = first_arg.item
+
+        instances: list[Instance] = []
+        if isinstance(first_arg, TypeVarType):
+            if first_arg.values:
+                for found in first_arg.values:
+                    item = get_proper_type(found)
+                    if isinstance(item, Instance):
+                        instances.append(item)
+                    else:
+                        ctx.api.fail(
+                            f"A value in the type var ({first_arg}) is unexpected: {item}: {type(item)}",
+                            ctx.context,
+                        )
+                        return AnyType(TypeOfAny.from_error)
+            else:
+                item = get_proper_type(first_arg.upper_bound)
+                if not isinstance(item, Instance):
+                    ctx.api.fail(
+                        f"Upper bound for type var ({first_arg}) is unexpected: {item}: {type(item)}",
+                        ctx.context,
+                    )
+                    return AnyType(TypeOfAny.from_error)
+                instances.append(item)
+
+        elif isinstance(first_arg, Instance):
+            instances.append(first_arg)
+
+        elif isinstance(first_arg, UnionType):
+            union_items = [get_proper_type(item) for item in first_arg.items]
+            union_pairs = [
+                (isinstance(part, TypeType), isinstance(part, Instance), part)
+                for part in union_items
+            ]
+            are_all_instances = all(
+                is_type or is_instance for is_type, is_instance, _ in union_pairs
+            )
+            if are_all_instances:
+                for part in union_items:
+                    found = part
+                    if isinstance(found, TypeType):
+                        is_type = True
+                        found = found.item
+                    if not isinstance(part, Instance):
+                        are_all_instances = False
+                        break
+                    instances.append(part)
+
+            if not are_all_instances:
+                ctx.api.fail(
+                    f"Expected only `type[MyClass]` or `MyClass` in a union provided to cast_as_concrete, got {union_items}",
+                    ctx.context,
+                )
+                return AnyType(TypeOfAny.from_error)
+        else:
+            ctx.api.fail(
+                f"cast_as_concrete must take a variable with a clear type, got {first_arg}: ({type(first_arg)})",
+                ctx.context,
+            )
+            return AnyType(TypeOfAny.from_error)
+
+        resolver = self.make_resolver(ctx=ctx)
+        resolved = resolver.resolve(
+            protocols.KnownAnnotations.CONCRETE, UnionType(tuple(instances))
+        )
+        if not resolved:
+            # Error would have already been sent out
+            return AnyType(TypeOfAny.from_error)
+
+        if isinstance(resolved, UnionType):
+            if is_type:
+                resolved = UnionType(tuple(TypeType(item) for item in resolved.items))
+        elif is_type:
+            resolved = TypeType(resolved)
+
+        return resolved
 
     def extended_get_attribute_resolve_manager_method(
         self,

--- a/extended_mypy_django_plugin/annotations.py
+++ b/extended_mypy_django_plugin/annotations.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-from typing import Generic, TypeVar, overload
+from typing import Generic, TypeVar
 
 from django.db import models
 
 T_Parent = TypeVar("T_Parent")
+T_Obj = TypeVar("T_Obj")
 
 
 class Concrete(Generic[T_Parent]):
@@ -26,17 +27,7 @@ class Concrete(Generic[T_Parent]):
     """
 
     @classmethod
-    @overload
-    def cast_as_concrete(cls, obj: type[T_Parent]) -> type[Concrete[T_Parent]]: ...
-
-    @classmethod
-    @overload
-    def cast_as_concrete(cls, obj: T_Parent) -> Concrete[T_Parent]: ...
-
-    @classmethod
-    def cast_as_concrete(
-        cls, obj: type[T_Parent] | T_Parent
-    ) -> type[Concrete[T_Parent]] | Concrete[T_Parent]:
+    def cast_as_concrete(cls, obj: T_Obj) -> T_Obj:
         """
         This can be used to change the type of an abstract django model to be only
         a concrete decedent.
@@ -53,12 +44,12 @@ class Concrete(Generic[T_Parent]):
                     abstract = True
 
                 @classmethod
-                def new(cls) -> Concrete[Self]:
+                def new(cls) -> Self:
                     cls = Concrete.cast_as_concrete(cls)
                     reveal_type(cls) # type[Concrete1] | type[Concrete2] | type[Concrete3] | ...
                     ...
 
-                def get_self(self) -> Concrete[Self]:
+                def get_self(self) -> Self:
                     self = Concrete.cast_as_concrete(self)
                     reveal_type(self) # Concrete1 | Concrete2 | Concrete3 | ...
                     ...


### PR DESCRIPTION
There are effectively two places where I can implement `Concrete.cast_as_concrete`

One way is with `get_dynamic_class_hook` and the other is with `get_method_hook/get_function_hook`

The former is what was implemented and the latter is what I've changed it to in this PR

With ``get_dynamic_class_hook`` I know what the return type is being assigned to and so I'm able to make it so that if you are reassigning `self` or `cls` it "just works"™. But the tradeoff there is that I don't have enough information to take in anything complicated and I'm able to deal with type vars.

In the next PR I make it so that you can't annotate type vars anymore and so I need `Concrete.cast_as_concrete` to be able to handle Type vars. So this PR moves the implementation into `get_method_hook`.

This also starts the advice of not using `Concrete[Self]`