### PR TITLE
Remove `Concrete.type_var`

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -14,6 +14,8 @@ Changelog
       However it means that in methods when using it to override ``self`` and ``cls``
       that we can no longer override those variables. In these cases use a different
       variable name as the result.
+    * Removed Concrete.type_var. Can use
+      ``TypeVar("T_Model", bound=Concrete[Model])`` instead
 
 .. _release-0.6.4:
 

--- a/docs/api/usage.rst
+++ b/docs/api/usage.rst
@@ -42,18 +42,20 @@ This also works for types:
     cls: type[Concrete1 | Concrete2 | Concrete3]
 
 
-Concrete.type_var
------------------
+Concrete TypeVar
+----------------
 
 To create a type var representing any one of the concrete models of an abstract
-model, create a ``TypeVar`` object using ``Concrete.type_var``:
+model, create a ``TypeVar`` object like normal and bind it to the concrete of
+the desired model:
 
 .. code-block:: python
 
     from extended_mypy_django_plugin import Concrete
+    from typing import TypeVar
 
 
-    T_Concrete = Concrete.type_var("T_Concrete", AbstractModel)
+    T_Concrete = TypeVar("T_Concrete", bound=Concrete[AbstractModel])
 
 
     def create_row(cls: type[T_Concrete]) -> T_Concrete:
@@ -65,7 +67,7 @@ model, create a ``TypeVar`` object using ``Concrete.type_var``:
 
     from typing import TypeVar
 
-    T_Concrete = TypeVar("T_Concrete", Concrete1, Concrete2, Concrete3)
+    T_Concrete = TypeVar("T_Concrete", bound=Concrete1 | Concrete2 | Concrete3)
 
 
     def create_row(cls: type[T_Concrete]) -> T_Concrete:
@@ -185,21 +187,22 @@ This also works on the concrete models themselves:
     qs1: models.QuerySet[Concrete1]
     qs2: Concrete2QuerySet
 
-It also works on the ``TypeVar`` objects returned by ``Concrete.type_var``:
+It also works on the ``TypeVar`` objects:
 
 .. code-block:: python
 
     from extended_mypy_django_plugin import Concrete, DefaultQuerySet
+    from typing import TypeVar
 
 
-    T_Concrete = Concrete.type_var("T_Concrete", AbstractModel)
+    T_Concrete = TypeVar("T_Concrete", bound=Concrete[AbstractModel])
 
 
     def get_qs(cls: type[T_Concrete]) -> DefaultQuerySet[T_Concrete]:
         return cls.objects.all()
 
     # --------------
-    # Essentially equivalent to
+    # Essentially (but not literally) equivalent to
     # --------------
 
     from typing import overload

--- a/example/djangoexample/views.py
+++ b/example/djangoexample/views.py
@@ -1,14 +1,18 @@
+from typing import TypeVar
+
 from django.http import HttpRequest, HttpResponse, HttpResponseBase
 
 from extended_mypy_django_plugin import Concrete, DefaultQuerySet
 
 from .exampleapp.models import Child1, Child2, Parent
 
-T_Child = Concrete.type_var("T_Child", Parent)
+T_Child = TypeVar("T_Child", bound=Concrete[Parent])
 
 
 def make_child(child: type[T_Child]) -> T_Child:
-    return child.objects.create()
+    created = child.objects.create()
+    assert isinstance(created, child)
+    return created
 
 
 def make_any_queryset(child: type[Concrete[Parent]]) -> DefaultQuerySet[Parent]:

--- a/extended_mypy_django_plugin/_plugin/analyze.py
+++ b/extended_mypy_django_plugin/_plugin/analyze.py
@@ -1,7 +1,5 @@
-from mypy.nodes import GDEF, AssignmentStmt, NameExpr, SymbolTableNode
-from mypy.plugin import AnalyzeTypeContext, DynamicClassDefContext
-from mypy.semanal import SemanticAnalyzer
-from mypy.types import Instance, ProperType, TypeType, TypeVarType, UnionType, get_proper_type
+from mypy.plugin import AnalyzeTypeContext
+from mypy.types import ProperType, TypeType, TypeVarType, UnionType, get_proper_type
 from mypy.types import Type as MypyType
 
 from . import protocols
@@ -54,60 +52,3 @@ class Analyzer:
             return ctx.type
         else:
             return resolved
-
-    def transform_type_var_classmethod(self, ctx: DynamicClassDefContext) -> None:
-        if len(ctx.call.args) != 2:
-            ctx.api.fail("Concrete.type_var takes exactly two arguments", ctx.call)
-            return None
-
-        # We need much more than is on the interface unfortunately
-        assert isinstance(ctx.api, SemanticAnalyzer)
-        sem_api = ctx.api
-
-        inside: str | None = None
-        if ctx.api.scope.classes and ctx.api.scope.functions:
-            inside = "method scope"
-        elif ctx.api.scope.classes:
-            inside = "class scope"
-        elif ctx.api.scope.functions:
-            inside = "function scope"
-
-        if inside:
-            # We modify the module scope in this hook, so make sure it's in module scope!
-            ctx.api.fail(
-                f"Can only use Concrete.type_var at module scope, rather than {inside}", ctx.call
-            )
-            return None
-
-        # This copies what mypy does to resolve TypeVars
-        # https://github.com/python/mypy/blob/v1.10.1/mypy/semanal.py#L4234
-        name = sem_api.extract_typevarlike_name(
-            AssignmentStmt([NameExpr(ctx.name)], ctx.call.callee), ctx.call
-        )
-        if name is None:
-            return None
-
-        second_arg = ctx.call.args[1]
-        parent_type = get_proper_type(sem_api.expr_to_analyzed_type(second_arg))
-
-        if not isinstance(parent_type, Instance):
-            if ctx.api.final_iteration:
-                ctx.api.fail(f"Failed to locate the model provided: {ctx.name}", ctx.call)
-            else:
-                ctx.api.defer()
-
-            return None
-
-        type_var_expr = self.make_resolver(ctx=ctx).type_var_expr_for(
-            model=parent_type.type,
-            name=name,
-            fullname=f"{ctx.api.cur_mod_id}.{name}",
-            object_type=ctx.api.named_type("builtins.object"),
-        )
-
-        # Note that we will override even if we've already generated the type var
-        # because it's possible for a first pass to have no values but a second to do have values
-        # And in between that we do need this to be a typevar expr
-        module = ctx.api.modules[ctx.api.cur_mod_id]
-        module.names[name] = SymbolTableNode(GDEF, type_var_expr, plugin_generated=True)
-        return None

--- a/extended_mypy_django_plugin/_plugin/annotation_resolver.py
+++ b/extended_mypy_django_plugin/_plugin/annotation_resolver.py
@@ -2,7 +2,7 @@ import functools
 from collections.abc import Iterator, Sequence
 from typing import TYPE_CHECKING, cast
 
-from mypy.nodes import Context, PlaceholderNode, TypeAlias, TypeInfo, TypeVarExpr
+from mypy.nodes import Context, PlaceholderNode, TypeAlias, TypeInfo
 from mypy.plugin import (
     AnalyzeTypeContext,
     AttributeContext,
@@ -306,27 +306,6 @@ class AnnotationResolver:
 
         else:
             assert_never(annotation)
-
-    def type_var_expr_for(
-        self, *, model: TypeInfo, name: str, fullname: str, object_type: Instance
-    ) -> TypeVarExpr:
-        try:
-            values = list(self._instances_from_aliases(self.get_concrete_aliases, model.fullname))
-        except ShouldDefer:
-            # In this case the type var will be analyzed again and given values
-            # or reach the call to fail below
-            values = []
-        else:
-            if not values:
-                self.fail(f"No concrete children found for {model.fullname}")
-
-        return TypeVarExpr(
-            name=name,
-            fullname=fullname,
-            values=list(values),
-            upper_bound=object_type,
-            default=AnyType(TypeOfAny.from_omitted_generics),
-        )
 
     def rewrap_concrete_type(
         self, *, annotation: protocols.KnownAnnotations, model_type: ProperType

--- a/extended_mypy_django_plugin/_plugin/protocols.py
+++ b/extended_mypy_django_plugin/_plugin/protocols.py
@@ -3,7 +3,7 @@ from collections.abc import Iterator, Mapping, MutableMapping, Sequence, Set
 from typing import TYPE_CHECKING, Optional, Protocol, TypeVar
 
 from mypy import errorcodes
-from mypy.nodes import SymbolTableNode, TypeInfo, TypeVarExpr
+from mypy.nodes import SymbolTableNode, TypeInfo
 from mypy.plugin import (
     AnalyzeTypeContext,
     AttributeContext,
@@ -187,13 +187,6 @@ class Resolver(Protocol):
         """
         Given some annotation and type inside the annotation, create an unbound type that can be
         recognised at a later stage where more information is available to continue analysis
-        """
-
-    def type_var_expr_for(
-        self, *, model: TypeInfo, name: str, fullname: str, object_type: Instance
-    ) -> TypeVarExpr:
-        """
-        Return the TypeVarExpr that represents the result of Concrete.type_var
         """
 
 

--- a/extended_mypy_django_plugin/annotations.py
+++ b/extended_mypy_django_plugin/annotations.py
@@ -13,15 +13,9 @@ class Concrete(Generic[T_Parent]):
     The ``Concrete`` annotation exists as a class with functionality for both
     runtime and static type checking time.
 
-    At runtime it can be used to create special ``TypeVar`` objects that may
-    represent any one of the concrete children of some abstract class and
-    it can be used to find those concrete children.
-
     At static type checking time (specifically with ``mypy``) it is used to create
     a type that represents the Union of all the concrete children of some
     abstract model.
-
-    .. automethod:: type_var
 
     .. automethod:: cast_as_concrete
     """
@@ -70,15 +64,6 @@ class Concrete(Generic[T_Parent]):
             raise RuntimeError("Expected a concrete instance")
 
         return obj
-
-    @classmethod
-    def type_var(cls, name: str, parent: type[models.Model] | str) -> TypeVar:
-        """
-        This returns an empty ``TypeVar`` at runtime, but the ``mypy`` plugin will
-        recognise that this ``TypeVar`` represents a choice of all the concrete
-        children of the specified model.
-        """
-        return TypeVar(name)
 
 
 class DefaultQuerySet(Generic[T_Parent]):

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -9,34 +9,6 @@ from pytest_mypy_plugins import OutputChecker
 
 
 class TestErrors:
-    def test_cant_create_concrete_type_var_outside_module_scope(self, scenario: Scenario) -> None:
-        @scenario.run_and_check_mypy_after
-        def _(expected: OutputBuilder) -> None:
-            scenario.file(
-                expected,
-                "main.py",
-                """
-                from extended_mypy_django_plugin import Concrete
-
-                from myapp.models import Parent
-
-                # No errors
-                T_Parent = Concrete.type_var("T_Parent", Parent)
-
-                class Thing:
-                    T_ClassScopeIsNotModuleScope = Concrete.type_var("T_ClassScopeIsNotModuleScope", Parent)
-                    # ^ ERROR(misc) ^ Can only use Concrete.type_var at module scope, rather than class scope
-
-                    def my_method(self) -> None:
-                        T_MethodScopeIsNotModuleScope = Concrete.type_var("T_MethodScopeIsNotModuleScope", Parent)
-                        # ^ ERROR(misc) ^ Can only use Concrete.type_var at module scope, rather than method scope
-
-                def my_function() -> None:
-                    T_FunctionScopeIsNotModuleScope = Concrete.type_var("T_FunctionScopeIsNotModuleScope", Parent)
-                    # ^ ERROR(misc) ^ Can only use Concrete.type_var at module scope, rather than function scope
-                """,
-            )
-
     def test_cant_use_typevar_concrete_annotation_in_function_or_method_typeguard(
         self, scenario: Scenario
     ) -> None:

--- a/tests/test_works.py
+++ b/tests/test_works.py
@@ -10,13 +10,16 @@ def test_works(scenario: Scenario) -> None:
             """
             from extended_mypy_django_plugin import Concrete, DefaultQuerySet
 
+            from typing import TypeVar
             from myapp.models import Parent, Child1, Child2
 
-            T_Child = Concrete.type_var("T_Child", Parent)
+            T_Child = TypeVar("T_Child", bound=Concrete[Parent])
 
 
             def make_child(child: type[T_Child]) -> T_Child:
-                return child.objects.create()
+                created = child.objects.create()
+                assert isinstance(created, child)
+                return created
 
 
             def make_any_queryset(child: type[Concrete[Parent]]) -> DefaultQuerySet[Parent]:


### PR DESCRIPTION
This changes removes the complexity of `Concrete.type_var` which would created a TypeVar with each concrete model as a separate choice.

It instead says we should use `TypeVar("T_Model", bound=Concrete[Model])`

This should be enough the same to be fine, is no less useful than `TypeVar("T_Model", bound=Model)` and has the other nice benefit of being a real TypeVar that mypy isn't sad about.