### PR TITLE
Reduce the priority of virtual dependencies

### DIFF
--- a/extended_mypy_django_plugin/django_analysis/virtual_dependencies/report.py
+++ b/extended_mypy_django_plugin/django_analysis/virtual_dependencies/report.py
@@ -124,7 +124,7 @@ class Report:
         # The type aliases it provides to resolve concrete annotations
         report_name = self.report_import_path.get(protocols.ImportPath(file_import_path))
         if report_name:
-            extra_dep = (10, report_name, -1)
+            extra_dep = (25, report_name, -1)
             if extra_dep not in super_deps:
                 super_deps = [*super_deps, extra_dep]
 
@@ -133,7 +133,7 @@ class Report:
         # This isn't necessary in daemon mode cause changes to that will make us restart dmypy
         # And when there is no cache everything is from scratch anyways
         if report_name and using_incremental_cache:
-            settings_dep = (10, django_settings_module, -1)
+            settings_dep = (25, django_settings_module, -1)
             if settings_dep not in super_deps:
                 super_deps = [*super_deps, settings_dep]
 

--- a/tests/django_analysis/virtual_dependencies/test_report.py
+++ b/tests/django_analysis/virtual_dependencies/test_report.py
@@ -464,7 +464,7 @@ class TestBuildingReport:
         made = report.additional_deps(
             file_import_path="django.db.models",
             imports=set(),
-            super_deps=(super_deps := [(10, "one.two", -1), (10, "two", -1)]),
+            super_deps=(super_deps := [(25, "one.two", -1), (25, "two", -1)]),
             django_settings_module="my.settings",
             using_incremental_cache=using_incremental_cache,
         )
@@ -492,7 +492,7 @@ class TestBuildingReport:
         made = report.additional_deps(
             file_import_path="some.place",
             imports=set(),
-            super_deps=(super_deps := [(10, "eight.nine", -1), (10, "typing.Protocol", 13)]),
+            super_deps=(super_deps := [(25, "eight.nine", -1), (25, "typing.Protocol", 13)]),
             django_settings_module="my.settings",
             using_incremental_cache=using_incremental_cache,
         )
@@ -501,7 +501,7 @@ class TestBuildingReport:
         made = report.additional_deps(
             file_import_path="some.place",
             imports={"one.two"},
-            super_deps=(super_deps := [(10, "hello.there", -1), (10, "typing.Protocol", 13)]),
+            super_deps=(super_deps := [(25, "hello.there", -1), (25, "typing.Protocol", 13)]),
             django_settings_module="my.settings",
             using_incremental_cache=using_incremental_cache,
         )
@@ -511,36 +511,36 @@ class TestBuildingReport:
         made = report.additional_deps(
             file_import_path="another.one",
             imports={"one.two"},
-            super_deps=(super_deps := [(10, "hello.there", -1), (10, "typing.Protocol", 13)]),
+            super_deps=(super_deps := [(25, "hello.there", -1), (25, "typing.Protocol", 13)]),
             django_settings_module="my.settings",
             using_incremental_cache=using_incremental_cache,
         )
         if using_incremental_cache:
             assert sorted(made) == sorted(
-                [*super_deps, (10, "v_another_one", -1), (10, "my.settings", -1)]
+                [*super_deps, (25, "v_another_one", -1), (25, "my.settings", -1)]
             )
         else:
-            assert sorted(made) == sorted([*super_deps, (10, "v_another_one", -1)])
+            assert sorted(made) == sorted([*super_deps, (25, "v_another_one", -1)])
 
         made = report.additional_deps(
             file_import_path="another.one",
             imports={"one.two.MyModel"},
-            super_deps=(super_deps := [(10, "hello.there", -1), (10, "typing.Protocol", 13)]),
+            super_deps=(super_deps := [(25, "hello.there", -1), (25, "typing.Protocol", 13)]),
             django_settings_module="my.settings",
             using_incremental_cache=using_incremental_cache,
         )
         if using_incremental_cache:
             assert sorted(made) == sorted(
-                [*super_deps, (10, "v_another_one", -1), (10, "my.settings", -1)]
+                [*super_deps, (25, "v_another_one", -1), (25, "my.settings", -1)]
             )
         else:
-            assert sorted(made) == sorted([*super_deps, (10, "v_another_one", -1)])
+            assert sorted(made) == sorted([*super_deps, (25, "v_another_one", -1)])
 
         # Also virtual_deps themselves don't add extra
         made = report.additional_deps(
             file_import_path="v_another_one",
             imports={"one.two.MyModel"},
-            super_deps=(super_deps := [(10, "hello.there", -1), (10, "typing.Protocol", 13)]),
+            super_deps=(super_deps := [(25, "hello.there", -1), (25, "typing.Protocol", 13)]),
             django_settings_module="my.settings",
             using_incremental_cache=using_incremental_cache,
         )

--- a/tests/test_concrete_annotations.py
+++ b/tests/test_concrete_annotations.py
@@ -531,6 +531,8 @@ class TestConcreteAnnotations:
                 from typing import Protocol, TypeVar
                 from extended_mypy_django_plugin import Concrete, DefaultQuerySet
 
+                T_Leader = TypeVar("T_Leader", bound=Concrete["Leader"])
+
                 class Leader(models.Model):
                     class Meta:
                         abstract = True
@@ -538,8 +540,6 @@ class TestConcreteAnnotations:
                 def thing() -> None:
                     all_concrete: Concrete[Leader]
                     # ^ REVEAL[leader-concrete-where-leader-defined] ^ Union[example.models.Follower1, example.models.Follower2]
-
-                T_Leader = TypeVar("T_Leader", bound=Concrete[Leader])
 
                 class Follower1QuerySet(models.QuerySet["Follower1"]):
                     ...


### PR DESCRIPTION
Prior to this the priority set on virtual dependencies was too high and it mean that mypy couldn't figure out the types of the fields on parent classes