### PR TITLE
Ensure that the virtual dep for a parent changes if only children change

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -3,6 +3,14 @@
 Changelog
 ---------
 
+.. _release-0.7.2:
+
+0.7.2 - TBD
+
+    * Fix a bug where the virtual dependency for a module containing an abstract
+      model wouldn't change if the concrete children changed in a way that
+      didn't also result in changing the abstract model.
+
 .. _release-0.7.1:
 
 0.7.1 - 5 August 2024

--- a/tests/django_analysis/usage/test_renaming_queryset.py
+++ b/tests/django_analysis/usage/test_renaming_queryset.py
@@ -1,0 +1,410 @@
+import pathlib
+import textwrap
+
+from extended_mypy_django_plugin_test_driver import ScenarioBuilder
+
+
+class TestRenamingQuerySet:
+    def test_can_move_queryset_from_abstract_class_to_concrete_children(
+        self, builder: ScenarioBuilder, tmp_path: pathlib.Path
+    ) -> None:
+        builder.set_installed_apps("parent", "child1", "child2")
+        for app in ("parent", "child1", "child2"):
+            builder.on(f"{app}/__init__.py").set("")
+            builder.on(f"{app}/apps.py").set(
+                f"""
+                from django.apps import AppConfig
+
+                class Config(AppConfig):
+                    name = "{app}"
+                """,
+            )
+
+        builder.on("parent/models.py").set(
+            """
+            from typing import TYPE_CHECKING, Union
+            from django.db import models
+
+
+            if TYPE_CHECKING:
+                from child1.models import Child1
+                from child2.models import Child2
+
+            class ParentQuerySet(models.QuerySet[Union["Child1", "Child2"]]):
+                pass
+
+            ParentManager = models.Manager.from_queryset(ParentQuerySet)
+
+
+            class Parent(models.Model):
+                objects = ParentManager()
+
+                class Meta:
+                    abstract = True
+            """
+        )
+        builder.on("child1/models.py").set(
+            """
+            from parent.models import Parent
+
+            class Child1(Parent):
+                pass
+            """
+        )
+        builder.on("child2/models.py").set(
+            """
+            from parent.models import Parent
+
+            class Child2(Parent):
+                pass
+            """
+        )
+
+        deps_dest = tmp_path / ".mypy_django_deps"
+
+        builder.populate_virtual_deps(deps_dest=deps_dest)
+
+        expected = {
+            "mod_3961720227.py": """
+                def interface__timestamp() -> None:
+                    return None
+
+                mod = "django.contrib.contenttypes.models"
+                summary = "__virtual_extended_mypy_django_plugin_report__.mod_3961720227::django.contrib.contenttypes.models::installed_apps=3376484868::significant=438215680"
+
+                import django.contrib.contenttypes.models
+                import django.db.models
+                ConcreteQuerySet__ContentType = django.db.models.QuerySet[django.contrib.contenttypes.models.ContentType]
+                Concrete__ContentType = django.contrib.contenttypes.models.ContentType
+                """,
+            "mod_566232296.py": """
+                def interface__timestamp() -> None:
+                    return None
+
+                mod = "child1.models"
+                summary = "__virtual_extended_mypy_django_plugin_report__.mod_566232296::child1.models::installed_apps=3376484868::significant=967422822"
+
+                import child1.models
+                import parent.models
+                ConcreteQuerySet__Child1 = parent.models.ParentQuerySet
+                Concrete__Child1 = child1.models.Child1
+                """,
+            "mod_566756585.py": """
+                def interface__timestamp() -> None:
+                    return None
+
+                mod = "child2.models"
+                summary = "__virtual_extended_mypy_django_plugin_report__.mod_566756585::child2.models::installed_apps=3376484868::significant=1344320379"
+
+                import child2.models
+                import parent.models
+                ConcreteQuerySet__Child2 = parent.models.ParentQuerySet
+                Concrete__Child2 = child2.models.Child2
+                """,
+            "mod_614729021.py": """
+                def interface__timestamp() -> None:
+                    return None
+
+                mod = "parent.models"
+                summary = "__virtual_extended_mypy_django_plugin_report__.mod_614729021::parent.models::installed_apps=3376484868::significant=309881802"
+
+                import child1.models
+                import child2.models
+                import parent.models
+                ConcreteQuerySet__Parent = parent.models.ParentQuerySet | parent.models.ParentQuerySet
+                Concrete__Parent = child1.models.Child1 | child2.models.Child2
+                """,
+        }
+
+        for fle in (deps_dest / "__virtual_extended_mypy_django_plugin_report__").iterdir():
+            want = textwrap.dedent(expected[fle.name]).strip()
+            assert fle.read_text().strip() == want
+
+        builder.on("parent/models.py").set(
+            """
+            from typing import TYPE_CHECKING, Union, TypeVar
+            from extended_mypy_django_plugin import Concrete
+            from django.db import models
+
+            T_Child = TypeVar("T_Child", bound=Concrete["Parent"])
+
+            class ParentQuerySet(models.QuerySet[T_Child]):
+                pass
+
+
+            class Parent(models.Model):
+                class Meta:
+                    abstract = True
+            """
+        )
+        builder.on("child1/models.py").set(
+            """
+            from parent.models import Parent, ParentQuerySet
+            from django.db import models
+
+            class Child1QuerySet(ParentQuerySet["Child1"]):
+                pass
+
+            Child1Manager = models.Manager.from_queryset(Child1QuerySet)
+
+            class Child1(Parent):
+                objects = Child1Manager()
+            """
+        )
+        builder.on("child2/models.py").set(
+            """
+            from parent.models import Parent, ParentQuerySet
+            from django.db import models
+
+            class Child2QuerySet(ParentQuerySet["Child1"]):
+                pass
+
+            Child2Manager = models.Manager.from_queryset(Child2QuerySet)
+
+
+            class Child2(Parent):
+                objects = Child2Manager()
+            """
+        )
+
+        expected["mod_566232296.py"] = """
+            def interface__timestamp() -> None:
+                return None
+
+            mod = "child1.models"
+            summary = "__virtual_extended_mypy_django_plugin_report__.mod_566232296::child1.models::installed_apps=3376484868::significant=2468262588"
+
+            import child1.models
+            ConcreteQuerySet__Child1 = child1.models.Child1QuerySet
+            Concrete__Child1 = child1.models.Child1
+            """
+
+        expected["mod_566756585.py"] = """
+            def interface__timestamp() -> None:
+                return None
+
+            mod = "child2.models"
+            summary = "__virtual_extended_mypy_django_plugin_report__.mod_566756585::child2.models::installed_apps=3376484868::significant=2877928147"
+
+            import child2.models
+            ConcreteQuerySet__Child2 = child2.models.Child2QuerySet
+            Concrete__Child2 = child2.models.Child2
+            """
+
+        expected["mod_614729021.py"] = """
+            def interface__timestamp() -> None:
+                return None
+
+            mod = "parent.models"
+            summary = "__virtual_extended_mypy_django_plugin_report__.mod_614729021::parent.models::installed_apps=3376484868::significant=3300935593"
+
+            import child1.models
+            import child2.models
+            import parent.models
+            ConcreteQuerySet__Parent = child1.models.Child1QuerySet | child2.models.Child2QuerySet
+            Concrete__Parent = child1.models.Child1 | child2.models.Child2
+            """
+
+        builder.populate_virtual_deps(deps_dest=deps_dest)
+
+        for fle in sorted(
+            (deps_dest / "__virtual_extended_mypy_django_plugin_report__").iterdir()
+        ):
+            want = textwrap.dedent(expected[fle.name]).strip()
+            assert fle.read_text().strip() == want
+
+    def test_can_rename_duplicate_concrete_querysets(
+        self, builder: ScenarioBuilder, tmp_path: pathlib.Path
+    ) -> None:
+        builder.set_installed_apps("parent", "child1", "child2")
+        for app in ("parent", "child1", "child2"):
+            builder.on(f"{app}/__init__.py").set("")
+            builder.on(f"{app}/apps.py").set(
+                f"""
+                from django.apps import AppConfig
+
+                class Config(AppConfig):
+                    name = "{app}"
+                """,
+            )
+
+        builder.on("parent/models.py").set(
+            """
+            from typing import TYPE_CHECKING, Union
+            from django.db import models
+
+
+            if TYPE_CHECKING:
+                from child1.models import Child1
+                from child2.models import Child2
+
+            class Parent(models.Model):
+                class Meta:
+                    abstract = True
+            """
+        )
+        builder.on("child1/models.py").set(
+            """
+            from parent.models import Parent
+            from django.db import models
+
+            class ChildQuerySet(models.QuerySet["Child"]):
+                pass
+
+            ChildManager = models.Manager.from_queryset(ChildQuerySet)
+
+            class Child(Parent):
+                objects = ChildManager()
+            """
+        )
+        builder.on("child2/models.py").set(
+            """
+            from parent.models import Parent
+            from django.db import models
+
+            class ChildQuerySet(models.QuerySet["Child"]):
+                pass
+
+            ChildManager = models.Manager.from_queryset(ChildQuerySet)
+
+            class Child(Parent):
+                objects = ChildManager()
+            """
+        )
+
+        deps_dest = tmp_path / ".mypy_django_deps"
+
+        pathlib.Path("/tmp/debug").unlink(missing_ok=True)
+        builder.populate_virtual_deps(deps_dest=deps_dest)
+
+        expected = {
+            "mod_3961720227.py": """
+                def interface__timestamp() -> None:
+                    return None
+
+                mod = "django.contrib.contenttypes.models"
+                summary = "__virtual_extended_mypy_django_plugin_report__.mod_3961720227::django.contrib.contenttypes.models::installed_apps=3376484868::significant=438215680"
+
+                import django.contrib.contenttypes.models
+                import django.db.models
+                ConcreteQuerySet__ContentType = django.db.models.QuerySet[django.contrib.contenttypes.models.ContentType]
+                Concrete__ContentType = django.contrib.contenttypes.models.ContentType
+                """,
+            "mod_566232296.py": """
+                def interface__timestamp() -> None:
+                    return None
+
+                mod = "child1.models"
+                summary = "__virtual_extended_mypy_django_plugin_report__.mod_566232296::child1.models::installed_apps=3376484868::significant=1784590644"
+
+                import child1.models
+                ConcreteQuerySet__Child = child1.models.ChildQuerySet
+                Concrete__Child = child1.models.Child
+                """,
+            "mod_566756585.py": """
+                def interface__timestamp() -> None:
+                    return None
+
+                mod = "child2.models"
+                summary = "__virtual_extended_mypy_django_plugin_report__.mod_566756585::child2.models::installed_apps=3376484868::significant=2056565059"
+
+                import child2.models
+                ConcreteQuerySet__Child = child2.models.ChildQuerySet
+                Concrete__Child = child2.models.Child
+                """,
+            "mod_614729021.py": """
+                def interface__timestamp() -> None:
+                    return None
+
+                mod = "parent.models"
+                summary = "__virtual_extended_mypy_django_plugin_report__.mod_614729021::parent.models::installed_apps=3376484868::significant=1191855927"
+
+                import child1.models
+                import child2.models
+                import parent.models
+                ConcreteQuerySet__Parent = child1.models.ChildQuerySet | child2.models.ChildQuerySet
+                Concrete__Parent = child1.models.Child | child2.models.Child
+                """,
+        }
+
+        for fle in (deps_dest / "__virtual_extended_mypy_django_plugin_report__").iterdir():
+            want = textwrap.dedent(expected[fle.name]).strip()
+            assert fle.read_text().strip() == want
+
+        builder.on("child1/models.py").set(
+            """
+            from parent.models import Parent
+            from django.db import models
+
+            class _Child1QuerySet(models.QuerySet["Child"]):
+                pass
+
+            ChildQuerySet = _Child1QuerySet
+            ChildManager = models.Manager.from_queryset(_Child1QuerySet)
+
+            class Child(Parent):
+                objects = ChildManager()
+            """
+        )
+        builder.on("child2/models.py").set(
+            """
+            from parent.models import Parent
+            from django.db import models
+
+            class _Child2QuerySet(models.QuerySet["Child"]):
+                pass
+
+            ChildQuerySet = _Child2QuerySet
+            ChildManager = models.Manager.from_queryset(_Child2QuerySet)
+
+            class Child(Parent):
+                objects = ChildManager()
+            """
+        )
+
+        expected["mod_566232296.py"] = """
+            def interface__timestamp() -> None:
+                return None
+
+            mod = "child1.models"
+            summary = "__virtual_extended_mypy_django_plugin_report__.mod_566232296::child1.models::installed_apps=3376484868::significant=2733879748"
+
+            import child1.models
+            ConcreteQuerySet__Child = child1.models._Child1QuerySet
+            Concrete__Child = child1.models.Child
+            """
+
+        expected["mod_566756585.py"] = """
+            def interface__timestamp() -> None:
+                return None
+
+            mod = "child2.models"
+            summary = "__virtual_extended_mypy_django_plugin_report__.mod_566756585::child2.models::installed_apps=3376484868::significant=3022762452"
+
+            import child2.models
+            ConcreteQuerySet__Child = child2.models._Child2QuerySet
+            Concrete__Child = child2.models.Child
+            """
+
+        expected["mod_614729021.py"] = """
+            def interface__timestamp() -> None:
+                return None
+
+            mod = "parent.models"
+            summary = "__virtual_extended_mypy_django_plugin_report__.mod_614729021::parent.models::installed_apps=3376484868::significant=1197557559"
+
+            import child1.models
+            import child2.models
+            import parent.models
+            ConcreteQuerySet__Parent = child1.models._Child1QuerySet | child2.models._Child2QuerySet
+            Concrete__Parent = child1.models.Child | child2.models.Child
+            """
+
+        pathlib.Path("/tmp/debug").write_text("")
+        builder.populate_virtual_deps(deps_dest=deps_dest)
+
+        for fle in sorted(
+            (deps_dest / "__virtual_extended_mypy_django_plugin_report__").iterdir()
+        ):
+            want = textwrap.dedent(expected[fle.name]).strip()
+            assert fle.read_text().strip() == want

--- a/tests/django_analysis/virtual_dependencies/generated_reports/__virtual__/mod_113708644.py
+++ b/tests/django_analysis/virtual_dependencies/generated_reports/__virtual__/mod_113708644.py
@@ -2,7 +2,7 @@ def interface____differentiated__12() -> None:
     return None
 
 mod = "django.contrib.sessions.base_session"
-summary = "__virtual__.mod_113708644::django.contrib.sessions.base_session::installed_apps=__installed_apps_hash__::significant=1879365353"
+summary = "__virtual__.mod_113708644::django.contrib.sessions.base_session::installed_apps=__installed_apps_hash__::significant=449501427"
 
 import django.contrib.sessions.base_session
 import django.contrib.sessions.models

--- a/tests/django_analysis/virtual_dependencies/generated_reports/__virtual__/mod_2833058650.py
+++ b/tests/django_analysis/virtual_dependencies/generated_reports/__virtual__/mod_2833058650.py
@@ -2,7 +2,7 @@ def interface____differentiated__11() -> None:
     return None
 
 mod = "django.contrib.auth.base_user"
-summary = "__virtual__.mod_2833058650::django.contrib.auth.base_user::installed_apps=__installed_apps_hash__::significant=1762274777"
+summary = "__virtual__.mod_2833058650::django.contrib.auth.base_user::installed_apps=__installed_apps_hash__::significant=3626250221"
 
 import django.contrib.auth.base_user
 import django.contrib.auth.models

--- a/tests/django_analysis/virtual_dependencies/generated_reports/__virtual__/mod_3347844205.py
+++ b/tests/django_analysis/virtual_dependencies/generated_reports/__virtual__/mod_3347844205.py
@@ -2,7 +2,7 @@ def interface____differentiated__5() -> None:
     return None
 
 mod = "djangoexample.exampleapp.models"
-summary = "__virtual__.mod_3347844205::djangoexample.exampleapp.models::installed_apps=__installed_apps_hash__::significant=2358377148"
+summary = "__virtual__.mod_3347844205::djangoexample.exampleapp.models::installed_apps=__installed_apps_hash__::significant=1019870410"
 
 import django.db.models
 import djangoexample.exampleapp.models

--- a/tests/django_analysis/virtual_dependencies/test_end2end.py
+++ b/tests/django_analysis/virtual_dependencies/test_end2end.py
@@ -98,7 +98,7 @@ class TestEnd2End:
 
         assert (
             report.version
-            == f"__virtual__|plugin:{VERSION}:installed_apps:__installed_apps_hash__|settings_types:2183014887|written_deps:917076629"
+            == f"__virtual__|plugin:{VERSION}:installed_apps:__installed_apps_hash__|settings_types:2183014887|written_deps:1749711409"
         )
         assert report.report == make_report(
             concrete_annotations={


### PR DESCRIPTION
Prior to this if the concrete children changed and there was no change in the parent model, then it's virtual dependency wouldn't be changed.

To fix this, the summary hash for a module will take into account the summary hash for all the modules that contain concrete models