### PR TITLE
Ensure virtual dependency reports have unique querysets

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -7,6 +7,7 @@ Changelog
 
 0.8.1 - TBD
     * Dropped support for mypy<1.16.0
+    * Virtual dependency reports now de-duplicate queryset unions
 
 .. _release-0.8.0:
 

--- a/extended_mypy_django_plugin/django_analysis/virtual_dependencies/report.py
+++ b/extended_mypy_django_plugin/django_analysis/virtual_dependencies/report.py
@@ -329,10 +329,16 @@ class VirtualDependencyScribe(Generic[protocols.T_VirtualDependency, protocols.T
                 added_imports.add(conc.import_path)
                 if conc.default_custom_queryset:
                     added_imports.add(conc.default_custom_queryset)
-                    querysets.append(conc.default_custom_queryset)
+                    queryset = str(conc.default_custom_queryset)
                 else:
                     added_imports.add(ImportPath("django.db.models.QuerySet"))
-                    querysets.append(f"django.db.models.QuerySet[{conc.import_path}]")
+                    queryset = f"django.db.models.QuerySet[{conc.import_path}]"
+
+                # Check for existence instead of using a set
+                # So that the order of the querysets matches the order
+                # of the concrete models
+                if queryset not in querysets:
+                    querysets.append(queryset)
 
             ns, name = ImportPath.split(model)
             concrete_name = f"Concrete__{name}"

--- a/extended_mypy_django_plugin/django_analysis/virtual_dependencies/report.py
+++ b/extended_mypy_django_plugin/django_analysis/virtual_dependencies/report.py
@@ -251,6 +251,7 @@ class VirtualDependencyScribe(Generic[protocols.T_VirtualDependency, protocols.T
                 str(summary.module_import_path),
                 f"installed_apps={self.installed_apps_hash}",
                 f"significant={significant}",
+                "v2",
             ]
         )
 

--- a/tests/django_analysis/usage/test_renaming_queryset.py
+++ b/tests/django_analysis/usage/test_renaming_queryset.py
@@ -70,7 +70,7 @@ class TestRenamingQuerySet:
                     return None
 
                 mod = "django.contrib.contenttypes.models"
-                summary = "__virtual_extended_mypy_django_plugin_report__.mod_3961720227::django.contrib.contenttypes.models::installed_apps=3376484868::significant=438215680"
+                summary = "__virtual_extended_mypy_django_plugin_report__.mod_3961720227::django.contrib.contenttypes.models::installed_apps=3376484868::significant=438215680::v2"
 
                 import django.contrib.contenttypes.models
                 import django.db.models
@@ -82,7 +82,7 @@ class TestRenamingQuerySet:
                     return None
 
                 mod = "child1.models"
-                summary = "__virtual_extended_mypy_django_plugin_report__.mod_566232296::child1.models::installed_apps=3376484868::significant=967422822"
+                summary = "__virtual_extended_mypy_django_plugin_report__.mod_566232296::child1.models::installed_apps=3376484868::significant=967422822::v2"
 
                 import child1.models
                 import parent.models
@@ -94,7 +94,7 @@ class TestRenamingQuerySet:
                     return None
 
                 mod = "child2.models"
-                summary = "__virtual_extended_mypy_django_plugin_report__.mod_566756585::child2.models::installed_apps=3376484868::significant=1344320379"
+                summary = "__virtual_extended_mypy_django_plugin_report__.mod_566756585::child2.models::installed_apps=3376484868::significant=1344320379::v2"
 
                 import child2.models
                 import parent.models
@@ -106,7 +106,7 @@ class TestRenamingQuerySet:
                     return None
 
                 mod = "parent.models"
-                summary = "__virtual_extended_mypy_django_plugin_report__.mod_614729021::parent.models::installed_apps=3376484868::significant=309881802"
+                summary = "__virtual_extended_mypy_django_plugin_report__.mod_614729021::parent.models::installed_apps=3376484868::significant=309881802::v2"
 
                 import child1.models
                 import child2.models
@@ -172,7 +172,7 @@ class TestRenamingQuerySet:
                 return None
 
             mod = "child1.models"
-            summary = "__virtual_extended_mypy_django_plugin_report__.mod_566232296::child1.models::installed_apps=3376484868::significant=2468262588"
+            summary = "__virtual_extended_mypy_django_plugin_report__.mod_566232296::child1.models::installed_apps=3376484868::significant=2468262588::v2"
 
             import child1.models
             ConcreteQuerySet__Child1 = child1.models.Child1QuerySet
@@ -184,7 +184,7 @@ class TestRenamingQuerySet:
                 return None
 
             mod = "child2.models"
-            summary = "__virtual_extended_mypy_django_plugin_report__.mod_566756585::child2.models::installed_apps=3376484868::significant=2877928147"
+            summary = "__virtual_extended_mypy_django_plugin_report__.mod_566756585::child2.models::installed_apps=3376484868::significant=2877928147::v2"
 
             import child2.models
             ConcreteQuerySet__Child2 = child2.models.Child2QuerySet
@@ -196,7 +196,7 @@ class TestRenamingQuerySet:
                 return None
 
             mod = "parent.models"
-            summary = "__virtual_extended_mypy_django_plugin_report__.mod_614729021::parent.models::installed_apps=3376484868::significant=3300935593"
+            summary = "__virtual_extended_mypy_django_plugin_report__.mod_614729021::parent.models::installed_apps=3376484868::significant=3300935593::v2"
 
             import child1.models
             import child2.models
@@ -283,7 +283,7 @@ class TestRenamingQuerySet:
                     return None
 
                 mod = "django.contrib.contenttypes.models"
-                summary = "__virtual_extended_mypy_django_plugin_report__.mod_3961720227::django.contrib.contenttypes.models::installed_apps=3376484868::significant=438215680"
+                summary = "__virtual_extended_mypy_django_plugin_report__.mod_3961720227::django.contrib.contenttypes.models::installed_apps=3376484868::significant=438215680::v2"
 
                 import django.contrib.contenttypes.models
                 import django.db.models
@@ -295,7 +295,7 @@ class TestRenamingQuerySet:
                     return None
 
                 mod = "child1.models"
-                summary = "__virtual_extended_mypy_django_plugin_report__.mod_566232296::child1.models::installed_apps=3376484868::significant=1784590644"
+                summary = "__virtual_extended_mypy_django_plugin_report__.mod_566232296::child1.models::installed_apps=3376484868::significant=1784590644::v2"
 
                 import child1.models
                 ConcreteQuerySet__Child = child1.models.ChildQuerySet
@@ -306,7 +306,7 @@ class TestRenamingQuerySet:
                     return None
 
                 mod = "child2.models"
-                summary = "__virtual_extended_mypy_django_plugin_report__.mod_566756585::child2.models::installed_apps=3376484868::significant=2056565059"
+                summary = "__virtual_extended_mypy_django_plugin_report__.mod_566756585::child2.models::installed_apps=3376484868::significant=2056565059::v2"
 
                 import child2.models
                 ConcreteQuerySet__Child = child2.models.ChildQuerySet
@@ -317,7 +317,7 @@ class TestRenamingQuerySet:
                     return None
 
                 mod = "parent.models"
-                summary = "__virtual_extended_mypy_django_plugin_report__.mod_614729021::parent.models::installed_apps=3376484868::significant=1191855927"
+                summary = "__virtual_extended_mypy_django_plugin_report__.mod_614729021::parent.models::installed_apps=3376484868::significant=1191855927::v2"
 
                 import child1.models
                 import child2.models
@@ -367,7 +367,7 @@ class TestRenamingQuerySet:
                 return None
 
             mod = "child1.models"
-            summary = "__virtual_extended_mypy_django_plugin_report__.mod_566232296::child1.models::installed_apps=3376484868::significant=2733879748"
+            summary = "__virtual_extended_mypy_django_plugin_report__.mod_566232296::child1.models::installed_apps=3376484868::significant=2733879748::v2"
 
             import child1.models
             ConcreteQuerySet__Child = child1.models._Child1QuerySet
@@ -379,7 +379,7 @@ class TestRenamingQuerySet:
                 return None
 
             mod = "child2.models"
-            summary = "__virtual_extended_mypy_django_plugin_report__.mod_566756585::child2.models::installed_apps=3376484868::significant=3022762452"
+            summary = "__virtual_extended_mypy_django_plugin_report__.mod_566756585::child2.models::installed_apps=3376484868::significant=3022762452::v2"
 
             import child2.models
             ConcreteQuerySet__Child = child2.models._Child2QuerySet
@@ -391,7 +391,7 @@ class TestRenamingQuerySet:
                 return None
 
             mod = "parent.models"
-            summary = "__virtual_extended_mypy_django_plugin_report__.mod_614729021::parent.models::installed_apps=3376484868::significant=1197557559"
+            summary = "__virtual_extended_mypy_django_plugin_report__.mod_614729021::parent.models::installed_apps=3376484868::significant=1197557559::v2"
 
             import child1.models
             import child2.models

--- a/tests/django_analysis/usage/test_renaming_queryset.py
+++ b/tests/django_analysis/usage/test_renaming_queryset.py
@@ -111,7 +111,7 @@ class TestRenamingQuerySet:
                 import child1.models
                 import child2.models
                 import parent.models
-                ConcreteQuerySet__Parent = parent.models.ParentQuerySet | parent.models.ParentQuerySet
+                ConcreteQuerySet__Parent = parent.models.ParentQuerySet
                 Concrete__Parent = child1.models.Child1 | child2.models.Child2
                 """,
         }

--- a/tests/django_analysis/virtual_dependencies/generated_reports/__virtual__/mod_113708644.py
+++ b/tests/django_analysis/virtual_dependencies/generated_reports/__virtual__/mod_113708644.py
@@ -2,7 +2,7 @@ def interface____differentiated__12() -> None:
     return None
 
 mod = "django.contrib.sessions.base_session"
-summary = "__virtual__.mod_113708644::django.contrib.sessions.base_session::installed_apps=__installed_apps_hash__::significant=449501427"
+summary = "__virtual__.mod_113708644::django.contrib.sessions.base_session::installed_apps=__installed_apps_hash__::significant=449501427::v2"
 
 import django.contrib.sessions.base_session
 import django.contrib.sessions.models

--- a/tests/django_analysis/virtual_dependencies/generated_reports/__virtual__/mod_2289830437.py
+++ b/tests/django_analysis/virtual_dependencies/generated_reports/__virtual__/mod_2289830437.py
@@ -2,7 +2,7 @@ def interface____differentiated__2() -> None:
     return None
 
 mod = "django.contrib.auth.models"
-summary = "__virtual__.mod_2289830437::django.contrib.auth.models::installed_apps=__installed_apps_hash__::significant=1922836542"
+summary = "__virtual__.mod_2289830437::django.contrib.auth.models::installed_apps=__installed_apps_hash__::significant=1922836542::v2"
 
 import django.contrib.auth.models
 import django.db.models

--- a/tests/django_analysis/virtual_dependencies/generated_reports/__virtual__/mod_2456226428.py
+++ b/tests/django_analysis/virtual_dependencies/generated_reports/__virtual__/mod_2456226428.py
@@ -2,7 +2,7 @@ def interface____differentiated__1() -> None:
     return None
 
 mod = "django.contrib.admin.models"
-summary = "__virtual__.mod_2456226428::django.contrib.admin.models::installed_apps=__installed_apps_hash__::significant=3233719984"
+summary = "__virtual__.mod_2456226428::django.contrib.admin.models::installed_apps=__installed_apps_hash__::significant=3233719984::v2"
 
 import django.contrib.admin.models
 import django.db.models

--- a/tests/django_analysis/virtual_dependencies/generated_reports/__virtual__/mod_2833058650.py
+++ b/tests/django_analysis/virtual_dependencies/generated_reports/__virtual__/mod_2833058650.py
@@ -2,7 +2,7 @@ def interface____differentiated__11() -> None:
     return None
 
 mod = "django.contrib.auth.base_user"
-summary = "__virtual__.mod_2833058650::django.contrib.auth.base_user::installed_apps=__installed_apps_hash__::significant=3626250221"
+summary = "__virtual__.mod_2833058650::django.contrib.auth.base_user::installed_apps=__installed_apps_hash__::significant=3626250221::v2"
 
 import django.contrib.auth.base_user
 import django.contrib.auth.models

--- a/tests/django_analysis/virtual_dependencies/generated_reports/__virtual__/mod_3074165738.py
+++ b/tests/django_analysis/virtual_dependencies/generated_reports/__virtual__/mod_3074165738.py
@@ -2,7 +2,7 @@ def interface____differentiated__4() -> None:
     return None
 
 mod = "django.contrib.sessions.models"
-summary = "__virtual__.mod_3074165738::django.contrib.sessions.models::installed_apps=__installed_apps_hash__::significant=4231118930"
+summary = "__virtual__.mod_3074165738::django.contrib.sessions.models::installed_apps=__installed_apps_hash__::significant=4231118930::v2"
 
 import django.contrib.sessions.models
 import django.db.models

--- a/tests/django_analysis/virtual_dependencies/generated_reports/__virtual__/mod_3327724610.py
+++ b/tests/django_analysis/virtual_dependencies/generated_reports/__virtual__/mod_3327724610.py
@@ -2,7 +2,7 @@ def interface____differentiated__7() -> None:
     return None
 
 mod = "djangoexample.relations1.models"
-summary = "__virtual__.mod_3327724610::djangoexample.relations1.models::installed_apps=__installed_apps_hash__::significant=448140218"
+summary = "__virtual__.mod_3327724610::djangoexample.relations1.models::installed_apps=__installed_apps_hash__::significant=448140218::v2"
 
 import django.db.models
 import djangoexample.relations1.models

--- a/tests/django_analysis/virtual_dependencies/generated_reports/__virtual__/mod_3328248899.py
+++ b/tests/django_analysis/virtual_dependencies/generated_reports/__virtual__/mod_3328248899.py
@@ -2,7 +2,7 @@ def interface____differentiated__8() -> None:
     return None
 
 mod = "djangoexample.relations2.models"
-summary = "__virtual__.mod_3328248899::djangoexample.relations2.models::installed_apps=__installed_apps_hash__::significant=1229019932"
+summary = "__virtual__.mod_3328248899::djangoexample.relations2.models::installed_apps=__installed_apps_hash__::significant=1229019932::v2"
 
 import django.db.models
 import djangoexample.relations2.models

--- a/tests/django_analysis/virtual_dependencies/generated_reports/__virtual__/mod_3347844205.py
+++ b/tests/django_analysis/virtual_dependencies/generated_reports/__virtual__/mod_3347844205.py
@@ -2,7 +2,7 @@ def interface____differentiated__5() -> None:
     return None
 
 mod = "djangoexample.exampleapp.models"
-summary = "__virtual__.mod_3347844205::djangoexample.exampleapp.models::installed_apps=__installed_apps_hash__::significant=1019870410"
+summary = "__virtual__.mod_3347844205::djangoexample.exampleapp.models::installed_apps=__installed_apps_hash__::significant=1019870410::v2"
 
 import django.db.models
 import djangoexample.exampleapp.models

--- a/tests/django_analysis/virtual_dependencies/generated_reports/__virtual__/mod_3537308831.py
+++ b/tests/django_analysis/virtual_dependencies/generated_reports/__virtual__/mod_3537308831.py
@@ -2,7 +2,7 @@ def interface____differentiated__6() -> None:
     return None
 
 mod = "djangoexample.exampleapp2.models"
-summary = "__virtual__.mod_3537308831::djangoexample.exampleapp2.models::installed_apps=__installed_apps_hash__::significant=1778215230"
+summary = "__virtual__.mod_3537308831::djangoexample.exampleapp2.models::installed_apps=__installed_apps_hash__::significant=1778215230::v2"
 
 import django.db.models
 import djangoexample.exampleapp2.models

--- a/tests/django_analysis/virtual_dependencies/generated_reports/__virtual__/mod_3808300370.py
+++ b/tests/django_analysis/virtual_dependencies/generated_reports/__virtual__/mod_3808300370.py
@@ -2,4 +2,4 @@ def interface____differentiated__10() -> None:
     return None
 
 mod = "djangoexample.empty_models.models"
-summary = "__virtual__.mod_3808300370::djangoexample.empty_models.models::installed_apps=__installed_apps_hash__::significant=1232670738"
+summary = "__virtual__.mod_3808300370::djangoexample.empty_models.models::installed_apps=__installed_apps_hash__::significant=1232670738::v2"

--- a/tests/django_analysis/virtual_dependencies/generated_reports/__virtual__/mod_3961720227.py
+++ b/tests/django_analysis/virtual_dependencies/generated_reports/__virtual__/mod_3961720227.py
@@ -2,7 +2,7 @@ def interface____differentiated__3() -> None:
     return None
 
 mod = "django.contrib.contenttypes.models"
-summary = "__virtual__.mod_3961720227::django.contrib.contenttypes.models::installed_apps=__installed_apps_hash__::significant=2877817555"
+summary = "__virtual__.mod_3961720227::django.contrib.contenttypes.models::installed_apps=__installed_apps_hash__::significant=2877817555::v2"
 
 import django.contrib.contenttypes.models
 import django.db.models

--- a/tests/django_analysis/virtual_dependencies/generated_reports/__virtual__/mod_4035906997.py
+++ b/tests/django_analysis/virtual_dependencies/generated_reports/__virtual__/mod_4035906997.py
@@ -2,6 +2,6 @@ def interface____differentiated__9() -> None:
     return None
 
 mod = "djangoexample.only_abstract.models"
-summary = "__virtual__.mod_4035906997::djangoexample.only_abstract.models::installed_apps=__installed_apps_hash__::significant=1262772787"
+summary = "__virtual__.mod_4035906997::djangoexample.only_abstract.models::installed_apps=__installed_apps_hash__::significant=1262772787::v2"
 
 import djangoexample.only_abstract.models

--- a/tests/django_analysis/virtual_dependencies/test_virtual_dependency_scribe.py
+++ b/tests/django_analysis/virtual_dependencies/test_virtual_dependency_scribe.py
@@ -189,7 +189,7 @@ class TestVirtualDependencyScribe:
                 return None
 
             mod = "djangoexample.exampleapp2.models"
-            summary = "__virtual__.mod_3537308831::djangoexample.exampleapp2.models::installed_apps=__installed_apps_hash__::significant=__hashed_for_great_good__"
+            summary = "__virtual__.mod_3537308831::djangoexample.exampleapp2.models::installed_apps=__installed_apps_hash__::significant=__hashed_for_great_good__::v2"
 
             import django.db.models
             import djangoexample.exampleapp2.models
@@ -204,6 +204,7 @@ class TestVirtualDependencyScribe:
                 "::djangoexample.exampleapp2.models"
                 "::installed_apps=__installed_apps_hash__"
                 "::significant=__hashed_for_great_good__"
+                "::v2"
             )
 
             written = scenario.scribe(hasher=hasher, virtual_dependency=virtual_dependency)
@@ -292,7 +293,7 @@ class TestVirtualDependencyScribe:
                 return None
 
             mod = "djangoexample.relations1.models"
-            summary = "__virtual__.mod_3327724610::djangoexample.relations1.models::installed_apps=__installed_apps_hash__::significant=__hashed_for_greater_good__"
+            summary = "__virtual__.mod_3327724610::djangoexample.relations1.models::installed_apps=__installed_apps_hash__::significant=__hashed_for_greater_good__::v2"
 
             import django.db.models
             import djangoexample.relations1.models
@@ -313,6 +314,7 @@ class TestVirtualDependencyScribe:
                 "::djangoexample.relations1.models"
                 "::installed_apps=__installed_apps_hash__"
                 "::significant=__hashed_for_greater_good__"
+                "::v2"
             )
 
             written = scenario.scribe(hasher=hasher, virtual_dependency=virtual_dependency)
@@ -364,7 +366,7 @@ class TestVirtualDependencyScribe:
                 return None
 
             mod = "djangoexample.empty_models.models"
-            summary = "__virtual__.mod_3808300370::djangoexample.empty_models.models::installed_apps=__installed_apps_hash__::significant=__hashed_for_bad__"
+            summary = "__virtual__.mod_3808300370::djangoexample.empty_models.models::installed_apps=__installed_apps_hash__::significant=__hashed_for_bad__::v2"
             """).strip()
 
             summary_hash = (
@@ -372,6 +374,7 @@ class TestVirtualDependencyScribe:
                 "::djangoexample.empty_models.models"
                 "::installed_apps=__installed_apps_hash__"
                 "::significant=__hashed_for_bad__"
+                "::v2"
             )
 
             written = scenario.scribe(hasher=hasher, virtual_dependency=virtual_dependency)


### PR DESCRIPTION
Prior to this it was possible for a virtual dependency report to add duplicate querysets when rendering the union of concrete querysets for a
model

This change is essentially purely aesthetic and has no functional difference