### PR TITLE
Use `HasTypeVars` query provided by mypy

### DIFF
--- a/extended_mypy_django_plugin/_plugin/analyze.py
+++ b/extended_mypy_django_plugin/_plugin/analyze.py
@@ -1,20 +1,8 @@
 from mypy.plugin import AnalyzeTypeContext
+from mypy.types import HasTypeVars, get_proper_type
 from mypy.types import Type as MypyType
-from mypy.types import TypeQuery, TypeVarType, get_proper_type
 
 from . import protocols
-
-
-class HasTypeVars(TypeQuery[bool]):
-    """
-    Find where we have a concrete annotation
-    """
-
-    def __init__(self) -> None:
-        super().__init__(any)
-
-    def visit_type_var(self, t: TypeVarType) -> bool:
-        return True
 
 
 class Analyzer:


### PR DESCRIPTION
Add compatibility for mypy 1.19 by using the query for this that mypy has already defined. Resolves the following crash:

```
...:213: error: INTERNAL ERROR -- Please try using mypy master on GitHub:
https://mypy.readthedocs.io/en/stable/common_issues.html#using-a-development-mypy-build
Please report a bug at https://github.com/python/mypy/issues
version: 1.19.0
Traceback (most recent call last):
  File "mypy/semanal.py", line 7564, in accept
  File "mypy/nodes.py", line 995, in accept
  File "mypy/semanal.py", line 978, in visit_func_def
  File "mypy/semanal.py", line 1020, in analyze_func_def
  File "mypy/typeanal.py", line 1191, in visit_callable_type
  File "mypy/typeanal.py", line 1921, in anal_type
  File "mypy/types.py", line 1096, in accept
  File "mypy/typeanal.py", line 285, in visit_unbound_type
  File "mypy/typeanal.py", line 456, in visit_unbound_type_nonoptional
  File "mypy/typeanal.py", line 629, in try_analyze_special_unbound_type
  File "mypy/typeanal.py", line 1921, in anal_type
  File "mypy/types.py", line 1096, in accept
  File "mypy/typeanal.py", line 285, in visit_unbound_type
  File "mypy/typeanal.py", line 456, in visit_unbound_type_nonoptional
  File "mypy/typeanal.py", line 662, in try_analyze_special_unbound_type
  File "mypy/typeanal.py", line 1921, in anal_type
  File "mypy/types.py", line 1096, in accept
  File "mypy/typeanal.py", line 285, in visit_unbound_type
  File "mypy/typeanal.py", line 347, in visit_unbound_type_nonoptional
  File ".../.venv/lib/python3.12/site-packages/extended_mypy_django_plugin/_plugin/plugin.py", line 183, in run
    return self.plugin.analyzer.analyze_type(ctx, extra)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../.venv/lib/python3.12/site-packages/extended_mypy_django_plugin/_plugin/analyze.py", line 43, in analyze_type
    if model_type.accept(HasTypeVars()):
                         ^^^^^^^^^^^^^
  File ".../.venv/lib/python3.12/site-packages/extended_mypy_django_plugin/_plugin/analyze.py", line 14, in __init__
    super().__init__(any)
TypeError: __init__() takes at most 0 arguments (1 given)
```