### PR TITLE
Add hide_queryset_annotations helper

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -10,6 +10,7 @@ Changelog
     * Dropped support for mypy<2.1.0
     * Dropped support for python<3.13
     * Dropped support for django-stubs<6.0.5,django<6.0.5
+    * Added ``extended_mypy_django_plugin.hide_queryset_annotations`` helper
 
 .. _release-0.8.2:
 

--- a/docs/api/usage.rst
+++ b/docs/api/usage.rst
@@ -193,3 +193,34 @@ This also works on the concrete models themselves:
 
     qs1: models.QuerySet[Concrete1]
     qs2: Concrete2QuerySet
+
+Hiding queryset annotations
+---------------------------
+
+Sometimes it can be useful to create a queryset using an annotation that isn't
+useful to callers.
+
+For example:
+
+.. code-block:: python
+
+    def some_filter(qs: MyQuerySet[MyModel]) -> MyQuerySet[MyModel]:
+        # Imagine a useful example
+        # The problem is that this fails because mypy believes the annotated
+        # type this resolves to should result in a `return-value` error here
+        return qs.annotate(max_value=Max("value")).filter(max_value__gt=10)
+
+In this case we can remove the queryset annotations:
+
+.. code-block:: python
+
+    from extended_django_mypy_plugin import hide_queryset_annotations
+
+    def some_filter(qs: MyQuerySet[MyModel]) -> MyQuerySet[MyModel]:
+        return hide_queryset_annotations(
+            qs.annotate(max_value=Max("value")).filter(max_value__gt=10)
+        )
+
+This helper does nothing at runtime and at static times errors will be produced
+if it's given something that isn't an instance of a queryset with a model we
+can determine.

--- a/extended_mypy_django_plugin/__init__.py
+++ b/extended_mypy_django_plugin/__init__.py
@@ -1,3 +1,3 @@
-from .annotations import Concrete, DefaultQuerySet
+from .annotations import Concrete, DefaultQuerySet, hide_queryset_annotations
 
-__all__ = ["Concrete", "DefaultQuerySet"]
+__all__ = ["Concrete", "DefaultQuerySet", "hide_queryset_annotations"]

--- a/extended_mypy_django_plugin/_plugin/plugin.py
+++ b/extended_mypy_django_plugin/_plugin/plugin.py
@@ -1,9 +1,16 @@
 import functools
 from typing import Generic, TypeVar
 
+from mypy import checker
 from mypy.nodes import Import, ImportAll, ImportFrom, MypyFile
 from mypy.options import Options
-from mypy.plugin import AnalyzeTypeContext, MethodContext, ReportConfigContext
+from mypy.plugin import (
+    AnalyzeTypeContext,
+    FunctionSigContext,
+    MethodContext,
+    ReportConfigContext,
+)
+from mypy.types import FunctionLike
 from mypy.types import Type as MypyType
 from mypy_django_plugin import main
 
@@ -47,6 +54,9 @@ class ExtendedMypyStubs(Generic[T_Report], main.NewSemanalDjangoPlugin):
         :no-index:
 
     .. autoattribute:: get_method_hook
+        :no-index:
+
+    .. autoattribute:: get_function_signature_hook
         :no-index:
     """
 
@@ -201,3 +211,26 @@ class ExtendedMypyStubs(Generic[T_Report], main.NewSemanalDjangoPlugin):
 
         def run(self, ctx: MethodContext) -> MypyType:
             return self.plugin.type_checker.modify_cast_as_concrete(ctx)
+
+    @hook.hook
+    class get_function_signature_hook(
+        PlainHook[protocols.Report, FunctionSigContext, FunctionLike]
+    ):
+        """
+        Used to implement the ``hide_queryset_annotations`` helper.
+
+        We use this hook to change the signature of that function where it is used such that it takes in the type it is
+        given and returns the same type minus any django-stubs queryset annotation information.
+        """
+
+        def choose(
+            self, *, fullname: str, super_hook: hook.MypyHook[FunctionSigContext, FunctionLike]
+        ) -> bool:
+            return fullname == "extended_mypy_django_plugin.annotations.hide_queryset_annotations"
+
+        def run(self, ctx: FunctionSigContext) -> FunctionLike:
+            return self.plugin.type_checker.modify_hide_queryset_annotations(
+                ctx=ctx,
+                django_context=self.plugin.django_context,
+                scope=None if not isinstance(ctx.api, checker.TypeChecker) else ctx.api.scope,
+            )

--- a/extended_mypy_django_plugin/_plugin/type_checker.py
+++ b/extended_mypy_django_plugin/_plugin/type_checker.py
@@ -1,10 +1,17 @@
+import mypy_django_plugin.django.context
+import mypy_django_plugin.lib.helpers
+from mypy import checker_shared
 from mypy.plugin import (
     FunctionContext,
+    FunctionSigContext,
     MethodContext,
 )
 from mypy.types import (
     AnyType,
+    FunctionLike,
     Instance,
+    TypeAliasType,
+    TypedDictType,
     TypeOfAny,
     TypeType,
     TypeVarType,
@@ -19,6 +26,89 @@ from . import protocols
 class TypeChecking:
     def __init__(self, *, make_resolver: protocols.ResolverMaker) -> None:
         self.make_resolver = make_resolver
+
+    def modify_hide_queryset_annotations(
+        self,
+        *,
+        ctx: FunctionSigContext,
+        django_context: mypy_django_plugin.django.context.DjangoContext,
+        scope: checker_shared.CheckerScope | None = None,
+    ) -> FunctionLike:
+        # First we need to make sure that what was pased in makes sense
+        # We expect exactly one argument
+        if len(ctx.args) != 1:
+            ctx.api.fail("hide_queryset_annotations takes only one argument", ctx.context)
+            return ctx.default_signature
+
+        # We need mypy to tell us the type of this argument
+        if not ctx.args[0]:
+            ctx.api.fail("Mypy failed to tell us the type of the first argument", ctx.context)
+            return ctx.default_signature
+
+        # At this point it is an expression, but we are at the part of mypy where we can analyze it
+        first_arg = get_proper_type(ctx.api.get_expression_type(ctx.args[0][0]))
+        if isinstance(first_arg, AnyType):
+            ctx.api.fail("Failed to determine the type of the first argument", ctx.context)
+            return ctx.default_signature
+
+        # If it's an alias then resolve what that's pointing to
+        if isinstance(first_arg, TypeAliasType) and first_arg.alias:
+            first_arg = get_proper_type(first_arg.alias.target)
+
+        # We can't get the information we want if we're in a class method
+        # So we only make sure we're passing in a queryset and otherwise ignore it
+        if isinstance(first_arg, TypeVarType) and first_arg.name == "Self":
+            if (
+                scope is None
+                or (enclosing := scope.enclosing_class()) is None
+                or not enclosing.has_base("django.db.models.query.QuerySet")
+            ):
+                ctx.api.fail("First argument must be a queryset", ctx.context)
+
+            return ctx.default_signature
+
+        # We expect a queryset instance, it doesn't make sense to hide annotations on a type
+        if not isinstance(first_arg, Instance):
+            ctx.api.fail("First argument must be an instance", ctx.context)
+            return ctx.default_signature
+
+        # Now we get to something interesting!
+        # We use django-stubs mypy plugin to extract the model type from our queryset
+        # This function returns None if it's not a queryset or it couldn't find the model
+        # We need the model because we want to make an annotation of the model without the annotations!
+        model = mypy_django_plugin.lib.helpers.extract_model_type_from_queryset(first_arg)
+        if model is None:
+            ctx.api.fail(
+                "Failed to determine a django model from the first argument (or it's not a queryset)",
+                ctx.context,
+            )
+            return ctx.default_signature
+
+        # Next we get that type of the model without annotations
+        if not mypy_django_plugin.lib.helpers.is_annotated_model(model.type):
+            django_model = Instance(model.type, [])
+        else:
+            django_model = Instance(model.type.bases[0].type, [])
+
+        # Then we need to make sure we carry across the row type if it's a TypedDict
+        # The second arg of a queryset will be a TypedDict if `.values` or `.values_list` has been used
+        # And this type of queryset is very different than without that so we don't want to lose this information
+        queryset_args: list[MypyType] = [django_model]
+        if len(first_arg.args) == 2:
+            second_arg = get_proper_type(first_arg.args[1])
+            if isinstance(second_arg, TypeAliasType) and second_arg.alias:
+                second_arg = get_proper_type(second_arg.alias.target)
+
+            if isinstance(second_arg, TypedDictType):
+                queryset_args.append(first_arg.args[1])
+
+        # And finally we change the signature of our `hide_queryset_annotations` function at this callsite
+        # Such that it takes in the type that we gave it
+        # And returns an instance of the queryset we were given such that it's in terms
+        # of the un-annotated model and any Values row type that we need to carry through
+        return ctx.default_signature.copy_modified(
+            arg_types=[first_arg], ret_type=Instance(first_arg.type, queryset_args)
+        )
 
     def modify_cast_as_concrete(self, ctx: FunctionContext | MethodContext) -> MypyType:
         if len(ctx.arg_types) != 1:

--- a/extended_mypy_django_plugin/annotations.py
+++ b/extended_mypy_django_plugin/annotations.py
@@ -8,6 +8,33 @@ T_Parent = TypeVar("T_Parent")
 T_Obj = TypeVar("T_Obj")
 
 
+def hide_queryset_annotations[T_QuerySet](queryset: T_QuerySet) -> T_QuerySet:
+    """
+    This helper is seen by the mypy plugin and is used to transform a queryset
+    type with annotations into a queryset type without annotations
+
+    At runtime it does nothing.
+
+    The purpose of this is when a queryset is annotated only for the filter that is
+    immediately applied to it when we don't need to share the annotation outside of
+    that context.
+
+    For example:
+
+    .. code-block::
+
+        from extended_mypy_django_plugin import hide_queryset_annotations
+
+        def filter_my_queryset(qs: MySpecialQuerySet[MyModel]) -> MySpecialQuerySet[MyModel]:
+            # Without the `hide_queryset_annotations` mypy will complain that we are returning
+            # MySpecialQuerySet[Annotated[MyModel, TypedDict({"some_field": ...})]]
+            return hide_queryset_annotations(
+                qs.annotate(some_field=...).filter(some_field__gt=3)
+            )
+    """
+    return queryset
+
+
 class Concrete(Generic[T_Parent]):
     """
     The ``Concrete`` annotation exists as a class with functionality for both

--- a/scripts/follower1/models/__init__.py
+++ b/scripts/follower1/models/__init__.py
@@ -1,3 +1,3 @@
-from .follower1 import Follower1
+from .follower1 import Follower1, Follower1QuerySet
 
-__all__ = ["Follower1"]
+__all__ = ["Follower1", "Follower1QuerySet"]

--- a/tests/test_hide_queryset_annotations.py
+++ b/tests/test_hide_queryset_annotations.py
@@ -1,0 +1,201 @@
+from extended_mypy_django_plugin_test_driver import ScenarioBuilder
+
+
+class TestHideQuerySetAnnotations:
+    def test_ignoring_annotations(self, builder: ScenarioBuilder) -> None:
+        @builder.run_and_check_after
+        def _() -> None:
+            builder.set_and_copy_installed_apps("leader", "follower1")
+            builder.on("main.py").set(
+                """
+                from follower1 import models as f1models
+                from django.db import models
+                from extended_mypy_django_plugin import hide_queryset_annotations
+
+                def not_using_helper() -> f1models.Follower1QuerySet[f1models.Follower1]:
+                    qs = f1models.Follower1.objects.all()
+
+                    return qs.annotate(value=models.Value(1)).filter(value=1)
+                    # ^ ERROR(return-value) ^ Incompatible return value type (got "Follower1QuerySet[Follower1@AnnotatedWith[TypedDict({'value': Any})], Follower1@AnnotatedWith[TypedDict({'value': Any})]]", expected "Follower1QuerySet[Follower1]")
+
+                def using_helper() -> f1models.Follower1QuerySet[f1models.Follower1]:
+                    qs = f1models.Follower1.objects.all()
+                    return hide_queryset_annotations(qs.annotate(value=models.Value(1)).filter(value=1))
+                """
+            )
+
+    def test_retains_row_type(self, builder: ScenarioBuilder) -> None:
+        @builder.run_and_check_after
+        def _() -> None:
+            builder.set_and_copy_installed_apps("leader", "follower1")
+            builder.on("main.py").set(
+                """
+                from follower1 import models as f1models
+                from django.db import models
+                from typing import TypedDict
+                from extended_mypy_django_plugin import hide_queryset_annotations
+
+                class _Row(TypedDict):
+                    good: bool
+
+                def returning_values() -> models.QuerySet[f1models.Follower1, _Row]:
+                    qs = f1models.Follower1.objects.all()
+
+                    annotated = qs.annotate(value=models.Value(1)).filter(value=1)
+                    # ^ REVEAL ^ follower1.models.follower1.Follower1QuerySet[follower1.models.follower1.Follower1@AnnotatedWith[TypedDict({'value': Any})], follower1.models.follower1.Follower1@AnnotatedWith[TypedDict({'value': Any})]]
+                    
+                    with_values = annotated.values("good")
+                    # ^ REVEAL ^ django.db.models.query.QuerySet[follower1.models.follower1.Follower1@AnnotatedWith[TypedDict({'value': Any})], TypedDict({'good': bool})]
+
+                    without_the_annotations = hide_queryset_annotations(with_values)
+                    # ^ REVEAL ^ django.db.models.query.QuerySet[follower1.models.follower1.Follower1, TypedDict({'good': bool})]
+
+                    return with_values
+                    # it seems django-stubs already is fine with this
+                """
+            )
+
+    def test_works_on_non_custom_querysets(self, builder: ScenarioBuilder) -> None:
+        @builder.run_and_check_after
+        def _() -> None:
+            builder.set_and_copy_installed_apps("leader", "follower1")
+            builder.on("main.py").set(
+                """
+                from follower1 import models as f1models
+                from django.db import models
+                from typing import TypedDict, Any
+                from extended_mypy_django_plugin import hide_queryset_annotations
+                from django_stubs_ext import WithAnnotations
+
+                class _Annotation(TypedDict):
+                    value: Any
+
+                type FollowerWithAnnotation = WithAnnotations[f1models.Follower1, _Annotation]
+
+                def without_helper(qs: models.QuerySet[FollowerWithAnnotation]) -> models.QuerySet[f1models.Follower1]:
+                    without_annotation = hide_queryset_annotations(qs)
+                    # ^ REVEAL ^ django.db.models.query.QuerySet[follower1.models.follower1.Follower1]
+
+                    return qs
+                    # it seems django-stubs already is fine with this
+                """
+            )
+
+    def test_works_in_custom_queryset_methods(self, builder: ScenarioBuilder) -> None:
+        @builder.run_and_check_after
+        def _() -> None:
+            builder.set_installed_apps("example")
+            builder.on("example/__init__.py").set("")
+
+            builder.on("example/apps.py").set(
+                """
+                from django.apps import AppConfig
+
+                class Config(AppConfig):
+                    name = "example"
+                """,
+            )
+
+            builder.on("example/models.py").set(
+                """
+                from __future__ import annotations
+
+                from django.db import models
+                from extended_mypy_django_plugin import hide_queryset_annotations
+                from typing import Self
+
+                class MyModelQuerySet[T_Model: MyModel = MyModel](models.QuerySet[T_Model]):
+                    def without_helper(self) -> Self:
+                        return self.annotate(value=models.Value(1)).filter(value=1)
+                        # Seems django-stubs already doesn't realise this is annotated
+
+                    def with_helper(self) -> Self:
+                        qs = self.annotate(value=models.Value(1)).filter(value=1)
+                        # ^ REVEAL ^ Self
+
+                        without_annotations = hide_queryset_annotations(qs)
+                        # ^ REVEAL ^ Self
+
+                        return without_annotations
+
+                class MyModel(models.Model):
+                    objects = MyModelQuerySet.as_manager()
+                """,
+            )
+
+            builder.on("main.py").set(
+                """
+                from example.models import MyModel
+
+                one = MyModel.objects.all().without_helper()
+                # ^ REVEAL[model] ^ example.models.MyModelQuerySet[example.models.MyModel]
+
+                two = MyModel.objects.all().with_helper()
+                # ^ REVEAL[model] ^ example.models.MyModelQuerySet[example.models.MyModel]
+                """,
+            )
+
+    def test_it_complains_when_passing_in_things_that_are_not_queryset_instances(
+        self, builder: ScenarioBuilder
+    ) -> None:
+        @builder.run_and_check_after
+        def _() -> None:
+            builder.set_and_copy_installed_apps("leader", "follower1")
+            builder.on("main.py").set(
+                """
+                from follower1 import models as f1models
+                from extended_mypy_django_plugin import hide_queryset_annotations
+                from typing import Self, Any
+                from django.db import models
+
+                hide_queryset_annotations(1)
+                # ^ ERROR(misc) ^ Failed to determine a django model from the first argument (or it's not a queryset)
+                
+                hide_queryset_annotations("asdf")
+                # ^ ERROR(misc) ^ Failed to determine a django model from the first argument (or it's not a queryset)
+
+                hide_queryset_annotations(f1models.Follower1)
+                # ^ ERROR(misc) ^ First argument must be an instance
+
+                hide_queryset_annotations(f1models.Follower1QuerySet)
+                # ^ ERROR(misc) ^ First argument must be an instance
+
+                class MyClass:
+                    def my_method(self) -> Self:
+                        return hide_queryset_annotations(self)
+                        # ^ ERROR(misc) ^ First argument must be a queryset
+
+                def do_not_know_type(arg: Any) -> None:
+                    hide_queryset_annotations(arg)
+                    # ^ ERROR(misc) ^ Failed to determine the type of the first argument
+                    
+                def do_not_know_model(arg: models.QuerySet[Any]) -> None:
+                    hide_queryset_annotations(arg)
+                    # ^ ERROR(misc) ^ Failed to determine a django model from the first argument (or it's not a queryset)
+                """
+            )
+
+    def test_can_access_helper_from_a_different_location(self, builder: ScenarioBuilder) -> None:
+        @builder.run_and_check_after
+        def _() -> None:
+            builder.set_and_copy_installed_apps("leader", "follower1")
+            builder.on("type_inference.py").set(
+                """
+                from extended_mypy_django_plugin import hide_queryset_annotations
+
+                hide_queryset_annotations = hide_queryset_annotations
+                """
+            )
+            builder.on("main.py").set(
+                """
+                from django.db import models
+                import type_inference
+                from follower1 import models as f1models
+
+                qs = f1models.Follower1.objects.all().annotate(value=models.Value(1)).filter(value=1)
+                # ^ REVEAL ^ follower1.models.follower1.Follower1QuerySet[follower1.models.follower1.Follower1@AnnotatedWith[TypedDict({'value': Any})], follower1.models.follower1.Follower1@AnnotatedWith[TypedDict({'value': Any})]]
+
+                without_annotations = type_inference.hide_queryset_annotations(qs)
+                # ^ REVEAL ^ follower1.models.follower1.Follower1QuerySet[follower1.models.follower1.Follower1]
+                """
+            )


### PR DESCRIPTION
It's useful to be able to tell mypy to ignore the queryset annotations when we've only added an annotation for a filter applied in that place.

For example when we want to return a non annotated queryset from a function, but require an annotation within that function to determine what's in the queryset

Currently when we do this we need to specify those annotations in the return type of such a function even when they aren't used outside that function

This is a response to https://github.com/typeddjango/django-stubs/issues/3382

---

AI Disclosure: **NONE**: I actively avoid LLMs: No LLM or any other machine learning technique or product was used during the ideation, creation or description of this change[.](https://ky.fyi/posts/ai-burnout)
