### PR TITLE
Fix hide_queryset_annotations for older django-stubs versions

### DIFF
--- a/docs/api/changelog.rst
+++ b/docs/api/changelog.rst
@@ -3,6 +3,13 @@
 Changelog
 ---------
 
+.. _release-0.9.1:
+
+0.9.1 - TBD
+
+    * Fixed ``hide_queryset_annotations`` to support django-stubs 6.0.1 and less specific
+      value types
+
 .. _release-0.9.0:
 
 0.9.0 - 29 May 2026

--- a/extended_mypy_django_plugin/_plugin/type_checker.py
+++ b/extended_mypy_django_plugin/_plugin/type_checker.py
@@ -1,5 +1,9 @@
+import importlib.metadata
+from typing import Any
+
 import mypy_django_plugin.django.context
 import mypy_django_plugin.lib.helpers
+import packaging.version
 from mypy import checker_shared
 from mypy.plugin import (
     FunctionContext,
@@ -21,6 +25,17 @@ from mypy.types import (
 from mypy.types import Type as MypyType
 
 from . import protocols
+
+
+def _extract_model_type_from_queryset(queryset_type: Instance) -> Instance | None:
+    args: list[Any] = [queryset_type]
+    stubs_version = packaging.version.Version(importlib.metadata.version("django-stubs"))
+    if stubs_version < packaging.version.Version("6.0.3"):
+        # after django-stubs 6.0.3 the second argument was removed cause it is unused
+        # A future version of extended-mypy-django-plugin will assume django-stubs>6.0.5
+        args.append(None)
+
+    return mypy_django_plugin.lib.helpers.extract_model_type_from_queryset(*args)
 
 
 class TypeChecking:
@@ -76,7 +91,8 @@ class TypeChecking:
         # We use django-stubs mypy plugin to extract the model type from our queryset
         # This function returns None if it's not a queryset or it couldn't find the model
         # We need the model because we want to make an annotation of the model without the annotations!
-        model = mypy_django_plugin.lib.helpers.extract_model_type_from_queryset(first_arg)
+        model = _extract_model_type_from_queryset(first_arg)
+
         if model is None:
             ctx.api.fail(
                 "Failed to determine a django model from the first argument (or it's not a queryset)",
@@ -99,7 +115,15 @@ class TypeChecking:
             if isinstance(second_arg, TypeAliasType) and second_arg.alias:
                 second_arg = get_proper_type(second_arg.alias.target)
 
-            if isinstance(second_arg, TypedDictType):
+            if (
+                # If it's a TypedDict
+                isinstance(second_arg, TypedDictType)
+                # Or some kind of mapping because mypy couldn't find a more specific type
+                or (
+                    isinstance(second_arg, Instance) and second_arg.type.has_base("typing.Mapping")
+                )
+            ):
+                # then we have a value queryset and we want to preserve that
                 queryset_args.append(first_arg.args[1])
 
         # And finally we change the signature of our `hide_queryset_annotations` function at this callsite

--- a/tests/test_concrete_annotations.py
+++ b/tests/test_concrete_annotations.py
@@ -1,8 +1,15 @@
+import importlib.metadata
 import textwrap
 
+import packaging.version
 import pytest
 from extended_mypy_django_plugin_test_driver import Scenario, ScenarioBuilder, ScenarioRunner
 from pytest_typing_runner import expectations, notices, runners
+
+
+def is_old_stubs() -> bool:
+    stubs_version = packaging.version.Version(importlib.metadata.version("django-stubs"))
+    return stubs_version < packaging.version.Version("6.0.2")
 
 
 class TestConcreteAnnotations:
@@ -419,6 +426,14 @@ class TestConcreteAnnotations:
                 """,
             )
 
+            if is_old_stubs():
+                builder.on("main.py").expect(
+                    notices.RemoveFromRevealedType(
+                        name="all-qs",
+                        remove="[example.models.Follower1, example.models.Follower1]",
+                    )
+                )
+
         @builder.run_and_check_after
         def _() -> None:
             builder.set_installed_apps("example", "example2")
@@ -483,13 +498,23 @@ class TestConcreteAnnotations:
                     ],
                     replace=True,
                 ),
-                notices.AddRevealedTypes(
-                    name="all-qs",
-                    revealed=[
-                        "example.models.Follower1QuerySet[example.models.Follower1, example.models.Follower1] | django.db.models.query.QuerySet[example.models.Follower2, example.models.Follower2] | django.db.models.query.QuerySet[example2.models.Follower3, example2.models.Follower3]"
-                    ],
-                    replace=True,
-                ),
+                *[
+                    notices.AddRevealedTypes(
+                        name="all-qs",
+                        revealed=[
+                            "example.models.Follower1QuerySet | django.db.models.query.QuerySet[example.models.Follower2, example.models.Follower2] | django.db.models.query.QuerySet[example2.models.Follower3, example2.models.Follower3]"
+                        ],
+                        replace=True,
+                    )
+                    if is_old_stubs()
+                    else notices.AddRevealedTypes(
+                        name="all-qs",
+                        revealed=[
+                            "example.models.Follower1QuerySet[example.models.Follower1, example.models.Follower1] | django.db.models.query.QuerySet[example.models.Follower2, example.models.Follower2] | django.db.models.query.QuerySet[example2.models.Follower3, example2.models.Follower3]"
+                        ],
+                        replace=True,
+                    )
+                ],
                 notices.AddRevealedTypes(
                     name="narrowed",
                     revealed=[
@@ -600,6 +625,22 @@ class TestConcreteAnnotations:
                 """,
             )
 
+            if is_old_stubs():
+                builder.on("main.py").expect(
+                    notices.RemoveFromRevealedType(
+                        name="all-qs1",
+                        remove="[example.models.Follower1, example.models.Follower1]",
+                    ),
+                    notices.RemoveFromRevealedType(
+                        name="all-qs2",
+                        remove="[example.models.Follower1, example.models.Follower1]",
+                    ),
+                    notices.RemoveFromRevealedType(
+                        name="all-qs3",
+                        remove="[example.models.Follower1, example.models.Follower1]",
+                    ),
+                )
+
         @builder.run_and_check_after
         def _() -> None:
             builder.set_installed_apps("example", "example2")
@@ -644,6 +685,10 @@ class TestConcreteAnnotations:
                 )
             )
 
+            follower1queryset = "example.models.Follower1QuerySet[example.models.Follower1, example.models.Follower1]"
+            if is_old_stubs():
+                follower1queryset = "example.models.Follower1QuerySet"
+
             builder.on("main.py").expect(
                 notices.AddRevealedTypes(
                     name="all-concrete",
@@ -656,21 +701,21 @@ class TestConcreteAnnotations:
                 notices.AddRevealedTypes(
                     name="all-qs1",
                     revealed=[
-                        "example.models.Follower1QuerySet[example.models.Follower1, example.models.Follower1] | django.db.models.query.QuerySet[example.models.Follower2, example.models.Follower2] | example2.models.Follower3QuerySet[example2.models.Follower3]"
+                        f"{follower1queryset} | django.db.models.query.QuerySet[example.models.Follower2, example.models.Follower2] | example2.models.Follower3QuerySet[example2.models.Follower3]"
                     ],
                     replace=True,
                 ),
                 notices.AddRevealedTypes(
                     name="all-qs2",
                     revealed=[
-                        "example.models.Follower1QuerySet[example.models.Follower1, example.models.Follower1] | django.db.models.query.QuerySet[example.models.Follower2, example.models.Follower2] | example2.models.Follower3QuerySet[example2.models.Follower3]"
+                        f"{follower1queryset} | django.db.models.query.QuerySet[example.models.Follower2, example.models.Follower2] | example2.models.Follower3QuerySet[example2.models.Follower3]"
                     ],
                     replace=True,
                 ),
                 notices.AddRevealedTypes(
                     name="all-qs3",
                     revealed=[
-                        "example.models.Follower1QuerySet[example.models.Follower1, example.models.Follower1] | django.db.models.query.QuerySet[example.models.Follower2, example.models.Follower2] | example2.models.Follower3QuerySet[example2.models.Follower3]"
+                        f"{follower1queryset} | django.db.models.query.QuerySet[example.models.Follower2, example.models.Follower2] | example2.models.Follower3QuerySet[example2.models.Follower3]"
                     ],
                     replace=True,
                 ),

--- a/tests/test_hide_queryset_annotations.py
+++ b/tests/test_hide_queryset_annotations.py
@@ -1,3 +1,6 @@
+import importlib.metadata
+
+import packaging.version
 from extended_mypy_django_plugin_test_driver import ScenarioBuilder
 
 
@@ -25,30 +28,39 @@ class TestHideQuerySetAnnotations:
             )
 
     def test_retains_row_type(self, builder: ScenarioBuilder) -> None:
+        stubs_version = packaging.version.Version(importlib.metadata.version("django-stubs"))
+        if stubs_version < packaging.version.Version("6.0.2"):
+            value_type = "dict[str, Any]"
+            row_type = "dict[str, Any]"
+        else:
+            # It's not till the later django-stubs that it understands the value type correctly
+            value_type = "TypedDict({'good': bool})"
+            row_type = "_Row"
+
         @builder.run_and_check_after
         def _() -> None:
             builder.set_and_copy_installed_apps("leader", "follower1")
             builder.on("main.py").set(
-                """
+                f"""
                 from follower1 import models as f1models
                 from django.db import models
-                from typing import TypedDict
+                from typing import TypedDict, Any
                 from extended_mypy_django_plugin import hide_queryset_annotations
 
                 class _Row(TypedDict):
                     good: bool
 
-                def returning_values() -> models.QuerySet[f1models.Follower1, _Row]:
+                def returning_values() -> models.QuerySet[f1models.Follower1, {row_type}]:
                     qs = f1models.Follower1.objects.all()
 
                     annotated = qs.annotate(value=models.Value(1)).filter(value=1)
-                    # ^ REVEAL ^ follower1.models.follower1.Follower1QuerySet[follower1.models.follower1.Follower1@AnnotatedWith[TypedDict({'value': Any})], follower1.models.follower1.Follower1@AnnotatedWith[TypedDict({'value': Any})]]
+                    # ^ REVEAL ^ follower1.models.follower1.Follower1QuerySet[follower1.models.follower1.Follower1@AnnotatedWith[TypedDict({{'value': Any}})], follower1.models.follower1.Follower1@AnnotatedWith[TypedDict({{'value': Any}})]]
                     
                     with_values = annotated.values("good")
-                    # ^ REVEAL ^ django.db.models.query.QuerySet[follower1.models.follower1.Follower1@AnnotatedWith[TypedDict({'value': Any})], TypedDict({'good': bool})]
+                    # ^ REVEAL ^ django.db.models.query.QuerySet[follower1.models.follower1.Follower1@AnnotatedWith[TypedDict({{'value': Any}})], {value_type}]
 
                     without_the_annotations = hide_queryset_annotations(with_values)
-                    # ^ REVEAL ^ django.db.models.query.QuerySet[follower1.models.follower1.Follower1, TypedDict({'good': bool})]
+                    # ^ REVEAL ^ django.db.models.query.QuerySet[follower1.models.follower1.Follower1, {value_type}]
 
                     return with_values
                     # it seems django-stubs already is fine with this

--- a/tools/pyproject.toml
+++ b/tools/pyproject.toml
@@ -17,7 +17,7 @@ docs = [
     "sphinx==8.0.2",
 ]
 old-django = [
-    "django-stubs==6.0.5",
+    "django-stubs==6.0.1",
     "django==6.0.5"
 ]
 new-django = [

--- a/uv.lock
+++ b/uv.lock
@@ -308,8 +308,31 @@ wheels = [
 
 [[package]]
 name = "django-stubs"
+version = "6.0.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.15'",
+    "python_full_version < '3.15'",
+]
+dependencies = [
+    { name = "django" },
+    { name = "django-stubs-ext" },
+    { name = "types-pyyaml" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ff/9a/78b442ab9254436b3195bffaf4e52d54aa32ac2b47ee1f8481f4614abb01/django_stubs-6.0.1.tar.gz", hash = "sha256:e1ca63634221b57a55e16562b9b6d1849aeee2cabfd0fc026084dbe8aa893366", size = 272906, upload-time = "2026-03-18T08:10:18.366Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/be/e9280ae94339f49d17af63b2ec508c9f11031196426a04cbdec1b0878d4a/django_stubs-6.0.1-py3-none-any.whl", hash = "sha256:d885044bd0876610f3eb969d6b5ed22f386002a879fdcb369cd8efa0502dbbce", size = 535867, upload-time = "2026-03-18T08:10:16.192Z" },
+]
+
+[[package]]
+name = "django-stubs"
 version = "6.0.5"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.15'",
+    "python_full_version < '3.15'",
+]
 dependencies = [
     { name = "django" },
     { name = "django-stubs-ext" },
@@ -1177,11 +1200,11 @@ docs = [
 ]
 new-django = [
     { name = "django" },
-    { name = "django-stubs" },
+    { name = "django-stubs", version = "6.0.5", source = { registry = "https://pypi.org/simple" } },
 ]
 old-django = [
     { name = "django" },
-    { name = "django-stubs" },
+    { name = "django-stubs", version = "6.0.1", source = { registry = "https://pypi.org/simple" } },
 ]
 
 [package.metadata]
@@ -1190,7 +1213,7 @@ requires-dist = [
     { name = "django", marker = "extra == 'new-django'", specifier = "==6.0.5" },
     { name = "django", marker = "extra == 'old-django'", specifier = "==6.0.5" },
     { name = "django-stubs", marker = "extra == 'new-django'", specifier = "==6.0.5" },
-    { name = "django-stubs", marker = "extra == 'old-django'", specifier = "==6.0.5" },
+    { name = "django-stubs", marker = "extra == 'old-django'", specifier = "==6.0.1" },
     { name = "mypy", specifier = "==2.1.0" },
     { name = "remote-pdb", specifier = "==2.1.0" },
     { name = "ruff", specifier = "==0.15.14" },


### PR DESCRIPTION
Turns out I forgot to test this feature on the version of django-stubs we actually use at the moment (6.0.1) and the helper I am using in django-stubs used to take a second parameter it wasn't using.

I also noticed that the logic to find Value querysets didn't correctly discover when the row type is not a TypedDict

---

AI Disclosure: **NONE**: I actively avoid LLMs: No LLM or any other machine learning technique or product was used during the ideation, creation or description of this change[.](https://ky.fyi/posts/ai-burnout)
